### PR TITLE
Reduce Git LFS bandwidth usage

### DIFF
--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -211,26 +211,26 @@ jobs:
   #         }
 
   #         Exit 0
-  docker:
-    name: docker demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: docker demo
-      run: |
-          cd "${{ github.workspace }}/demos/docker"
-          npm ci
-          npm test
+  # docker:
+  #   name: docker demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: docker demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/docker"
+  #         npm ci
+  #         npm test
 
-          # The docker demo has many options in the powershell script which are not tested.
-          # For now it will require manual testing on the docker demo powershell scripts to
-          # make sure everything is working as expected.
+  #         # The docker demo has many options in the powershell script which are not tested.
+  #         # For now it will require manual testing on the docker demo powershell scripts to
+  #         # make sure everything is working as expected.
   # fixtures:
   #   name: fixtures demo
   #   needs: [checkout-repo]
@@ -331,19 +331,19 @@ jobs:
       # accessibility-lighthouse, 
       # code-coverage-with-istanbul-via-webpack-babel-plugin,
       # code-coverage-with-monocart-reporter,
-      docker,
+      # docker,
       # fixtures,
       # monocart-reporter-advanced-config,
       # stale-screenshots-cleanup,
     ]
     permissions:
       actions: write
-      checks: write
+      # checks: write
       contents: write
-      deployments: write
+      # deployments: write
       id-token: write
       issues: write
-      discussions: write
+      # discussions: write
       # packages: write
       # pages: write
       # pull-requests: write

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -32,42 +32,42 @@ jobs:
       with:
         name: ${{ env.REPO_ARTIFACT_NAME }}
         path: ${{ github.workspace }}
-  accessibility-axe:
-    name: accessibility-axe demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: accessibility-axe demo
-      run: |
-          cd "${{ github.workspace }}/demos/accessibility-axe"
-          npm ci
-          npx playwright install --with-deps
-          npm test | Tee-Object -Variable testOutput
+  # accessibility-axe:
+  #   name: accessibility-axe demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: accessibility-axe demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/accessibility-axe"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test | Tee-Object -Variable testOutput
 
-          # Check that all is as expected. Should have 3 and only 3 failed tests.
+  #         # Check that all is as expected. Should have 3 and only 3 failed tests.
 
-          $expectedFailed = $false
-          foreach($outputLine in $testOutput)
-          {
-            if($outputLine.Contains("3 failed"))
-            {
-              $expectedFailed = $true
-            }
-          }
+  #         $expectedFailed = $false
+  #         foreach($outputLine in $testOutput)
+  #         {
+  #           if($outputLine.Contains("3 failed"))
+  #           {
+  #             $expectedFailed = $true
+  #           }
+  #         }
 
-          if(!$expectedFailed)
-          {
-            Write-Output "::error::Failed running the accessibility-axe demo tests. Expected exactly 3 failed tests."
-            Exit 1
-          }
+  #         if(!$expectedFailed)
+  #         {
+  #           Write-Output "::error::Failed running the accessibility-axe demo tests. Expected exactly 3 failed tests."
+  #           Exit 1
+  #         }
 
-          Exit 0
+  #         Exit 0
   # accessibility-lighthouse:
   #   name: accessibility-lighthouse demo
   #   needs: [checkout-repo]
@@ -211,26 +211,26 @@ jobs:
   #         }
 
   #         Exit 0
-  # docker:
-  #   name: docker demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: docker demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/docker"
-  #         npm ci
-  #         npm test
+  docker:
+    name: docker demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: docker demo
+      run: |
+          cd "${{ github.workspace }}/demos/docker"
+          npm ci
+          npm test
 
-  #         # The docker demo has many options in the powershell script which are not tested.
-  #         # For now it will require manual testing on the docker demo powershell scripts to
-  #         # make sure everything is working as expected.
+          # The docker demo has many options in the powershell script which are not tested.
+          # For now it will require manual testing on the docker demo powershell scripts to
+          # make sure everything is working as expected.
   # fixtures:
   #   name: fixtures demo
   #   needs: [checkout-repo]
@@ -327,29 +327,29 @@ jobs:
     name: Delete repo artifact
     needs: [
       checkout-repo,
-      accessibility-axe, 
+      # accessibility-axe, 
       # accessibility-lighthouse, 
       # code-coverage-with-istanbul-via-webpack-babel-plugin,
       # code-coverage-with-monocart-reporter,
-      # docker,
+      docker,
       # fixtures,
       # monocart-reporter-advanced-config,
       # stale-screenshots-cleanup,
     ]
     permissions:
-      actions: write
-      checks: write
+      # actions: write
+      # checks: write
       contents: write
-      deployments: write
-      id-token: write
-      issues: write
-      discussions: write
-      packages: write
-      pages: write
-      pull-requests: write
-      repository-projects: write
-      security-events: write
-      statuses: write
+      # deployments: write
+      # id-token: write
+      # issues: write
+      # discussions: write
+      # packages: write
+      # pages: write
+      # pull-requests: write
+      # repository-projects: write
+      # security-events: write
+      # statuses: write
     runs-on: ubuntu-latest
     steps:
     - name: Delete repo artifact

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -337,13 +337,13 @@ jobs:
       # stale-screenshots-cleanup,
     ]
     permissions:
-      # actions: write
-      # checks: write
+      actions: write
+      checks: write
       contents: write
-      # deployments: write
-      # id-token: write
-      # issues: write
-      # discussions: write
+      deployments: write
+      id-token: write
+      issues: write
+      discussions: write
       # packages: write
       # pages: write
       # pull-requests: write

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -337,8 +337,9 @@ jobs:
       # stale-screenshots-cleanup,
     ]
     permissions:
-      # actions: write
-      contents: write
+      actions: write
+      # contents: write
+      # issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Delete repo artifact

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -13,20 +13,36 @@ defaults:
   run:
     shell: pwsh
 
+env:
+  REPO_ARTIFACT_NAME : repo
 
 jobs:
-  accessibility-axe:
-    name: accessibility-axe demo
+  checkout-repo:
+    name: Checkout repo
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        lfs: true
+    - name: Upload repo
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+        path: ${{ github.workspace }}
+  accessibility-axe:
+    name: accessibility-axe demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: accessibility-axe demo
       run: |
           cd "${{ github.workspace }}/demos/accessibility-axe"
@@ -54,16 +70,15 @@ jobs:
           Exit 0
   accessibility-lighthouse:
     name: accessibility-lighthouse demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: accessibility-lighthouse demo
       run: |
           cd "${{ github.workspace }}/demos/accessibility-lighthouse"
@@ -92,16 +107,15 @@ jobs:
           Exit 0
   code-coverage-with-istanbul-via-webpack-babel-plugin:
     name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
       run: |
           cd "${{ github.workspace }}/demos/code-coverage-with-istanbul-via-webpack-babel-plugin"
@@ -149,16 +163,15 @@ jobs:
           Exit 0
   code-coverage-with-monocart-reporter:
     name: code-coverage-with-monocart-reporter demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: code-coverage-with-monocart-reporter demo
       run: |
           cd "${{ github.workspace }}/demos/code-coverage-with-monocart-reporter"
@@ -200,18 +213,15 @@ jobs:
           Exit 0
   docker:
     name: docker demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
       with:
-        lfs: true
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: docker demo
       run: |
           cd "${{ github.workspace }}/demos/docker"
@@ -223,16 +233,15 @@ jobs:
           # make sure everything is working as expected.
   fixtures:
     name: fixtures demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: fixtures demo
       run: |
           cd "${{ github.workspace }}/demos/fixtures"
@@ -275,18 +284,15 @@ jobs:
           Exit 0
   monocart-reporter-advanced-config:
     name: monocart-reporter-advanced-config demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: windows-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
       with:
-        lfs: true
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: monocart-reporter-advanced-config demo
       run: |
           cd "${{ github.workspace }}/demos/monocart-reporter-advanced-config"
@@ -299,18 +305,15 @@ jobs:
           # is working.
   stale-screenshots-cleanup:
     name: stale-screenshots-cleanup demo
+    needs: [checkout-repo]
     permissions:
       contents: read
     runs-on: windows-latest
     steps:
-    - name: Dump github context for debug purposes
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: $env:GITHUB_CONTEXT
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
       with:
-        lfs: true
+        name: ${{ env.REPO_ARTIFACT_NAME }}
     - name: stale-screenshots-cleanup demo
       run: |
           cd "${{ github.workspace }}/demos/stale-screenshots-cleanup"
@@ -321,3 +324,26 @@ jobs:
           # There's no easy way to test that this demo is working as expected.
           # For now this demo relies on manual testing to make sure everything
           # is working.
+  delete-repo-artifact:
+    name: Delete repo artifact
+    needs: [
+      checkout-repo,
+      accessibility-axe, 
+      accessibility-lighthouse, 
+      code-coverage-with-istanbul-via-webpack-babel-plugin,
+      code-coverage-with-monocart-reporter,
+      docker,
+      fixtures,
+      monocart-reporter-advanced-config,
+      stale-screenshots-cleanup,
+    ]
+    if: always() && needs.checkout-repo.result == 'success'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Delete repo artifact
+      uses: geekyeggo/delete-artifact@v4
+      with:
+          token: ${{ github.token }}
+          name: ${{ env.REPO_ARTIFACT_NAME }}

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -338,18 +338,8 @@ jobs:
     ]
     permissions:
       actions: write
-      # checks: write
       contents: write
-      # deployments: write
-      id-token: write
-      issues: write
-      # discussions: write
-      # packages: write
-      # pages: write
-      # pull-requests: write
-      # repository-projects: write
-      # security-events: write
-      # statuses: write
+      # issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Delete repo artifact

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -337,9 +337,8 @@ jobs:
       # stale-screenshots-cleanup,
     ]
     permissions:
-      actions: write
+      # actions: write
       contents: write
-      # issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Delete repo artifact

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -32,314 +32,312 @@ jobs:
       with:
         name: ${{ env.REPO_ARTIFACT_NAME }}
         path: ${{ github.workspace }}
-  # accessibility-axe:
-  #   name: accessibility-axe demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: accessibility-axe demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/accessibility-axe"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test | Tee-Object -Variable testOutput
+  accessibility-axe:
+    name: accessibility-axe demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: accessibility-axe demo
+      run: |
+          cd "${{ github.workspace }}/demos/accessibility-axe"
+          npm ci
+          npx playwright install --with-deps
+          npm test | Tee-Object -Variable testOutput
 
-  #         # Check that all is as expected. Should have 3 and only 3 failed tests.
+          # Check that all is as expected. Should have 3 and only 3 failed tests.
 
-  #         $expectedFailed = $false
-  #         foreach($outputLine in $testOutput)
-  #         {
-  #           if($outputLine.Contains("3 failed"))
-  #           {
-  #             $expectedFailed = $true
-  #           }
-  #         }
+          $expectedFailed = $false
+          foreach($outputLine in $testOutput)
+          {
+            if($outputLine.Contains("3 failed"))
+            {
+              $expectedFailed = $true
+            }
+          }
 
-  #         if(!$expectedFailed)
-  #         {
-  #           Write-Output "::error::Failed running the accessibility-axe demo tests. Expected exactly 3 failed tests."
-  #           Exit 1
-  #         }
+          if(!$expectedFailed)
+          {
+            Write-Output "::error::Failed running the accessibility-axe demo tests. Expected exactly 3 failed tests."
+            Exit 1
+          }
 
-  #         Exit 0
-  # accessibility-lighthouse:
-  #   name: accessibility-lighthouse demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: accessibility-lighthouse demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/accessibility-lighthouse"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test
+          Exit 0
+  accessibility-lighthouse:
+    name: accessibility-lighthouse demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: accessibility-lighthouse demo
+      run: |
+          cd "${{ github.workspace }}/demos/accessibility-lighthouse"
+          npm ci
+          npx playwright install --with-deps
+          npm test
 
-  #         # Check that the lighthouse audit worked as expected.
-  #         # The check is done by verifying that the audit-report.json produced by lighthouse
-  #         # contains the expected score results. If this file doesn't exist or doesn't have
-  #         # the expected scores then it should be an indication that something is wrong.
+          # Check that the lighthouse audit worked as expected.
+          # The check is done by verifying that the audit-report.json produced by lighthouse
+          # contains the expected score results. If this file doesn't exist or doesn't have
+          # the expected scores then it should be an indication that something is wrong.
 
-  #         $auditReport = Get-ChildItem -Path . -Filter audit-report.json -Recurse -ErrorAction SilentlyContinue -Force
-  #         $auditReportJson = Get-Content -Raw $auditReport | ConvertFrom-Json
-  #         $performanceCategory = $auditReportJson.categories | where { $_.name -eq "Performance" }
-  #         $accessibilityCategory = $auditReportJson.categories | where { $_.name -eq "Accessibility" }
-  #         $bestPracticesCategory = $auditReportJson.categories | where { $_.name -eq "Best Practices" }
-  #         $seoCategory = $auditReportJson.categories | where { $_.name -eq "SEO" }
+          $auditReport = Get-ChildItem -Path . -Filter audit-report.json -Recurse -ErrorAction SilentlyContinue -Force
+          $auditReportJson = Get-Content -Raw $auditReport | ConvertFrom-Json
+          $performanceCategory = $auditReportJson.categories | where { $_.name -eq "Performance" }
+          $accessibilityCategory = $auditReportJson.categories | where { $_.name -eq "Accessibility" }
+          $bestPracticesCategory = $auditReportJson.categories | where { $_.name -eq "Best Practices" }
+          $seoCategory = $auditReportJson.categories | where { $_.name -eq "SEO" }
 
-  #         if($performanceCategory.score -ne 1 -OR $accessibilityCategory.score -ne 0.93 -OR $bestPracticesCategory.score -ne 1 -OR $seoCategory.score -ne 0.89)
-  #         {
-  #           Write-Output "::error::Failed running the accessibility-lighthouse demo tests. Audit report didn't produce expected scores."
-  #           Exit 1
-  #         }
+          if($performanceCategory.score -ne 1 -OR $accessibilityCategory.score -ne 0.93 -OR $bestPracticesCategory.score -ne 1 -OR $seoCategory.score -ne 0.89)
+          {
+            Write-Output "::error::Failed running the accessibility-lighthouse demo tests. Audit report didn't produce expected scores."
+            Exit 1
+          }
 
-  #         Exit 0
-  # code-coverage-with-istanbul-via-webpack-babel-plugin:
-  #   name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/code-coverage-with-istanbul-via-webpack-babel-plugin"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test
+          Exit 0
+  code-coverage-with-istanbul-via-webpack-babel-plugin:
+    name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
+      run: |
+          cd "${{ github.workspace }}/demos/code-coverage-with-istanbul-via-webpack-babel-plugin"
+          npm ci
+          npx playwright install --with-deps
+          npm test
 
-  #         # Check that the code coverage worked as expected.
-  #         # The check is done by running the command to generate the code coverage
-  #         # and asserting on the values of the summary report.
+          # Check that the code coverage worked as expected.
+          # The check is done by running the command to generate the code coverage
+          # and asserting on the values of the summary report.
 
-  #         npm run coverage:report | Tee-Object -Variable coverageSummary
+          npm run coverage:report | Tee-Object -Variable coverageSummary
 
-  #         $expectedStatements = $false
-  #         $expectedBranches = $false
-  #         $expectedFunctions = $false
-  #         $expectedLines = $false
+          $expectedStatements = $false
+          $expectedBranches = $false
+          $expectedFunctions = $false
+          $expectedLines = $false
 
-  #         foreach($coverageLine in $coverageSummary)
-  #         {
-  #           if($coverageLine.Contains("Statements   : 88.88% ( 8/9 )"))
-  #           {
-  #             $expectedStatements = $true
-  #           }
-  #           elseif($coverageLine.Contains("Branches     : 100% ( 2/2 )"))
-  #           {
-  #             $expectedBranches = $true
-  #           }
-  #           elseif($coverageLine.Contains("Functions    : 50% ( 1/2 )"))
-  #           {
-  #             $expectedFunctions = $true
-  #           }
-  #           elseif($coverageLine.Contains("Lines        : 100% ( 8/8 )"))
-  #           {
-  #             $expectedLines = $true
-  #           }
-  #         }
+          foreach($coverageLine in $coverageSummary)
+          {
+            if($coverageLine.Contains("Statements   : 88.88% ( 8/9 )"))
+            {
+              $expectedStatements = $true
+            }
+            elseif($coverageLine.Contains("Branches     : 100% ( 2/2 )"))
+            {
+              $expectedBranches = $true
+            }
+            elseif($coverageLine.Contains("Functions    : 50% ( 1/2 )"))
+            {
+              $expectedFunctions = $true
+            }
+            elseif($coverageLine.Contains("Lines        : 100% ( 8/8 )"))
+            {
+              $expectedLines = $true
+            }
+          }
 
-  #         if(!$expectedStatements -OR !$expectedBranches -OR !$expectedFunctions -OR !$expectedLines)
-  #         {
-  #           Write-Output "::error::Failed running the code-coverage-with-istanbul-via-webpack-babel-plugin demo. Code coverage summary is different from what is expected."
-  #           Exit 1
-  #         }
+          if(!$expectedStatements -OR !$expectedBranches -OR !$expectedFunctions -OR !$expectedLines)
+          {
+            Write-Output "::error::Failed running the code-coverage-with-istanbul-via-webpack-babel-plugin demo. Code coverage summary is different from what is expected."
+            Exit 1
+          }
 
-  #         Exit 0
-  # code-coverage-with-monocart-reporter:
-  #   name: code-coverage-with-monocart-reporter demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: code-coverage-with-monocart-reporter demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/code-coverage-with-monocart-reporter"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test | Tee-Object -Variable testOutput
+          Exit 0
+  code-coverage-with-monocart-reporter:
+    name: code-coverage-with-monocart-reporter demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: code-coverage-with-monocart-reporter demo
+      run: |
+          cd "${{ github.workspace }}/demos/code-coverage-with-monocart-reporter"
+          npm ci
+          npx playwright install --with-deps
+          npm test | Tee-Object -Variable testOutput
 
-  #         # Check that the code coverage worked as expected.
-  #         # The check is done by asserting on the values of the summary report and
-  #         # veryfing that the expected coverage report files were created
+          # Check that the code coverage worked as expected.
+          # The check is done by asserting on the values of the summary report and
+          # veryfing that the expected coverage report files were created
 
-  #         $expectedLines = $false
+          $expectedLines = $false
 
-  #         foreach($testLine in $testOutput)
-  #         {
-  #           if($testLine.Contains("99.72 %"))
-  #           {
-  #             $expectedLines = $true
-  #           }
-  #         }
+          foreach($testLine in $testOutput)
+          {
+            if($testLine.Contains("99.72 %"))
+            {
+              $expectedLines = $true
+            }
+          }
 
-  #         if(!$expectedLines)
-  #         {
-  #           Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Code coverage summary is different from what is expected."
-  #           Exit 1
-  #         }
+          if(!$expectedLines)
+          {
+            Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Code coverage summary is different from what is expected."
+            Exit 1
+          }
 
-  #         $cobertura = Test-Path ./test-results/code-coverage/cobertura/code-coverage.cobertura.xml -PathType Leaf
-  #         $v8Report = Test-Path ./test-results/code-coverage/v8/index.html -PathType Leaf
-  #         $htmlSpaReport = Test-Path ./test-results/code-coverage/html-spa/index.html -PathType Leaf
-  #         $lcovReport = Test-Path ./test-results/code-coverage/lcov/code-coverage.lcov.info -PathType Leaf
+          $cobertura = Test-Path ./test-results/code-coverage/cobertura/code-coverage.cobertura.xml -PathType Leaf
+          $v8Report = Test-Path ./test-results/code-coverage/v8/index.html -PathType Leaf
+          $htmlSpaReport = Test-Path ./test-results/code-coverage/html-spa/index.html -PathType Leaf
+          $lcovReport = Test-Path ./test-results/code-coverage/lcov/code-coverage.lcov.info -PathType Leaf
 
-  #         if(!$cobertura -OR !$v8Report -OR !$htmlSpaReport -OR !$lcovReport)
-  #         {
-  #           Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Expected 4 reports but at least one is missing."
-  #           Exit 1
-  #         }
+          if(!$cobertura -OR !$v8Report -OR !$htmlSpaReport -OR !$lcovReport)
+          {
+            Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Expected 4 reports but at least one is missing."
+            Exit 1
+          }
 
-  #         Exit 0
-  # docker:
-  #   name: docker demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: docker demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/docker"
-  #         npm ci
-  #         npm test
+          Exit 0
+  docker:
+    name: docker demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: docker demo
+      run: |
+          cd "${{ github.workspace }}/demos/docker"
+          npm ci
+          npm test
 
-  #         # The docker demo has many options in the powershell script which are not tested.
-  #         # For now it will require manual testing on the docker demo powershell scripts to
-  #         # make sure everything is working as expected.
-  # fixtures:
-  #   name: fixtures demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: fixtures demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/fixtures"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test | Tee-Object -Variable testOutput
+          # The docker demo has many options in the powershell script which are not tested.
+          # For now it will require manual testing on the docker demo powershell scripts to
+          # make sure everything is working as expected.
+  fixtures:
+    name: fixtures demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: fixtures demo
+      run: |
+          cd "${{ github.workspace }}/demos/fixtures"
+          npm ci
+          npx playwright install --with-deps
+          npm test | Tee-Object -Variable testOutput
 
-  #         # Check that all is as expected. Should have 9 failed, 1 skipped and
-  #         # 8 passed tests.
+          # Check that all is as expected. Should have 9 failed, 1 skipped and
+          # 8 passed tests.
 
-  #         $expectedFailed = $false
-  #         $expectedSkipped = $false
-  #         $expectedPassed = $false
+          $expectedFailed = $false
+          $expectedSkipped = $false
+          $expectedPassed = $false
 
-  #         foreach($outputLine in $testOutput)
-  #         {
-  #           if($outputLine.Contains("9 failed"))
-  #           {
-  #             $expectedFailed = $true
-  #           }
-  #           elseif($outputLine.Contains("1 skipped"))
-  #           {
-  #             $expectedSkipped = $true
-  #           }
-  #           elseif($outputLine.Contains("8 passed"))
-  #           {
-  #             $expectedPassed = $true
-  #           }
-  #         }
+          foreach($outputLine in $testOutput)
+          {
+            if($outputLine.Contains("9 failed"))
+            {
+              $expectedFailed = $true
+            }
+            elseif($outputLine.Contains("1 skipped"))
+            {
+              $expectedSkipped = $true
+            }
+            elseif($outputLine.Contains("8 passed"))
+            {
+              $expectedPassed = $true
+            }
+          }
 
-  #         if(!$expectedFailed -OR !$expectedSkipped -OR !$expectedPassed)
-  #         {
-  #           Write-Output "expectedFailed=$expectedFailed"
-  #           Write-Output "expectedSkipped=$expectedSkipped"
-  #           Write-Output "expectedPassed=$expectedPassed"
-  #           Write-Output "::error::Failed running the fixtures demo tests. Expected 9 failed, 1 skipped and 8 passed tests."
-  #           Exit 1
-  #         }
+          if(!$expectedFailed -OR !$expectedSkipped -OR !$expectedPassed)
+          {
+            Write-Output "expectedFailed=$expectedFailed"
+            Write-Output "expectedSkipped=$expectedSkipped"
+            Write-Output "expectedPassed=$expectedPassed"
+            Write-Output "::error::Failed running the fixtures demo tests. Expected 9 failed, 1 skipped and 8 passed tests."
+            Exit 1
+          }
 
-  #         Exit 0
-  # monocart-reporter-advanced-config:
-  #   name: monocart-reporter-advanced-config demo
-  #   needs: [checkout-repo]
-  #   permissions:
-  #     contents: read
-  #   runs-on: windows-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: monocart-reporter-advanced-config demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/monocart-reporter-advanced-config"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test
+          Exit 0
+  monocart-reporter-advanced-config:
+    name: monocart-reporter-advanced-config demo
+    needs: [checkout-repo]
+    permissions:
+      contents: read
+    runs-on: windows-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: monocart-reporter-advanced-config demo
+      run: |
+          cd "${{ github.workspace }}/demos/monocart-reporter-advanced-config"
+          npm ci
+          npx playwright install --with-deps
+          npm test
 
-  #         # There's no easy way to test that this demo is working as expected.
-  #         # For now this demo relies on manual testing to make sure everything
-  #         # is working.
-  # stale-screenshots-cleanup:
-  #   name: stale-screenshots-cleanup demo
-  #   needs: [checkout-repo]
-  #   permissions: write-all
-  #   runs-on: windows-latest
-  #   steps:
-  #   - name: Download repo from workflow artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: ${{ env.REPO_ARTIFACT_NAME }}
-  #   - name: stale-screenshots-cleanup demo
-  #     run: |
-  #         cd "${{ github.workspace }}/demos/stale-screenshots-cleanup"
-  #         npm ci
-  #         npx playwright install --with-deps
-  #         npm test
+          # There's no easy way to test that this demo is working as expected.
+          # For now this demo relies on manual testing to make sure everything
+          # is working.
+  stale-screenshots-cleanup:
+    name: stale-screenshots-cleanup demo
+    needs: [checkout-repo]
+    permissions: write-all
+    runs-on: windows-latest
+    steps:
+    - name: Download repo from workflow artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.REPO_ARTIFACT_NAME }}
+    - name: stale-screenshots-cleanup demo
+      run: |
+          cd "${{ github.workspace }}/demos/stale-screenshots-cleanup"
+          npm ci
+          npx playwright install --with-deps
+          npm test
 
-  #         # There's no easy way to test that this demo is working as expected.
-  #         # For now this demo relies on manual testing to make sure everything
-  #         # is working.
+          # There's no easy way to test that this demo is working as expected.
+          # For now this demo relies on manual testing to make sure everything
+          # is working.
   delete-repo-artifact:
     name: Delete repo artifact
     needs: [
       checkout-repo,
-      # accessibility-axe, 
-      # accessibility-lighthouse, 
-      # code-coverage-with-istanbul-via-webpack-babel-plugin,
-      # code-coverage-with-monocart-reporter,
-      # docker,
-      # fixtures,
-      # monocart-reporter-advanced-config,
-      # stale-screenshots-cleanup,
+      accessibility-axe, 
+      accessibility-lighthouse, 
+      code-coverage-with-istanbul-via-webpack-babel-plugin,
+      code-coverage-with-monocart-reporter,
+      docker,
+      fixtures,
+      monocart-reporter-advanced-config,
+      stale-screenshots-cleanup,
     ]
     permissions:
       actions: write
-      # contents: write
-      # issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Delete repo artifact

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -306,8 +306,7 @@ jobs:
   stale-screenshots-cleanup:
     name: stale-screenshots-cleanup demo
     needs: [checkout-repo]
-    permissions:
-      contents: read
+    permissions: write-all
     runs-on: windows-latest
     steps:
     - name: Download repo from workflow artifacts
@@ -337,7 +336,6 @@ jobs:
       monocart-reporter-advanced-config,
       stale-screenshots-cleanup,
     ]
-    if: always() && needs.checkout-repo.result == 'success'
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-demos.yml
+++ b/.github/workflows/build-test-demos.yml
@@ -68,276 +68,288 @@ jobs:
           }
 
           Exit 0
-  accessibility-lighthouse:
-    name: accessibility-lighthouse demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: accessibility-lighthouse demo
-      run: |
-          cd "${{ github.workspace }}/demos/accessibility-lighthouse"
-          npm ci
-          npx playwright install --with-deps
-          npm test
+  # accessibility-lighthouse:
+  #   name: accessibility-lighthouse demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: accessibility-lighthouse demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/accessibility-lighthouse"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test
 
-          # Check that the lighthouse audit worked as expected.
-          # The check is done by verifying that the audit-report.json produced by lighthouse
-          # contains the expected score results. If this file doesn't exist or doesn't have
-          # the expected scores then it should be an indication that something is wrong.
+  #         # Check that the lighthouse audit worked as expected.
+  #         # The check is done by verifying that the audit-report.json produced by lighthouse
+  #         # contains the expected score results. If this file doesn't exist or doesn't have
+  #         # the expected scores then it should be an indication that something is wrong.
 
-          $auditReport = Get-ChildItem -Path . -Filter audit-report.json -Recurse -ErrorAction SilentlyContinue -Force
-          $auditReportJson = Get-Content -Raw $auditReport | ConvertFrom-Json
-          $performanceCategory = $auditReportJson.categories | where { $_.name -eq "Performance" }
-          $accessibilityCategory = $auditReportJson.categories | where { $_.name -eq "Accessibility" }
-          $bestPracticesCategory = $auditReportJson.categories | where { $_.name -eq "Best Practices" }
-          $seoCategory = $auditReportJson.categories | where { $_.name -eq "SEO" }
+  #         $auditReport = Get-ChildItem -Path . -Filter audit-report.json -Recurse -ErrorAction SilentlyContinue -Force
+  #         $auditReportJson = Get-Content -Raw $auditReport | ConvertFrom-Json
+  #         $performanceCategory = $auditReportJson.categories | where { $_.name -eq "Performance" }
+  #         $accessibilityCategory = $auditReportJson.categories | where { $_.name -eq "Accessibility" }
+  #         $bestPracticesCategory = $auditReportJson.categories | where { $_.name -eq "Best Practices" }
+  #         $seoCategory = $auditReportJson.categories | where { $_.name -eq "SEO" }
 
-          if($performanceCategory.score -ne 1 -OR $accessibilityCategory.score -ne 0.93 -OR $bestPracticesCategory.score -ne 1 -OR $seoCategory.score -ne 0.89)
-          {
-            Write-Output "::error::Failed running the accessibility-lighthouse demo tests. Audit report didn't produce expected scores."
-            Exit 1
-          }
+  #         if($performanceCategory.score -ne 1 -OR $accessibilityCategory.score -ne 0.93 -OR $bestPracticesCategory.score -ne 1 -OR $seoCategory.score -ne 0.89)
+  #         {
+  #           Write-Output "::error::Failed running the accessibility-lighthouse demo tests. Audit report didn't produce expected scores."
+  #           Exit 1
+  #         }
 
-          Exit 0
-  code-coverage-with-istanbul-via-webpack-babel-plugin:
-    name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
-      run: |
-          cd "${{ github.workspace }}/demos/code-coverage-with-istanbul-via-webpack-babel-plugin"
-          npm ci
-          npx playwright install --with-deps
-          npm test
+  #         Exit 0
+  # code-coverage-with-istanbul-via-webpack-babel-plugin:
+  #   name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: code-coverage-with-istanbul-via-webpack-babel-plugin demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/code-coverage-with-istanbul-via-webpack-babel-plugin"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test
 
-          # Check that the code coverage worked as expected.
-          # The check is done by running the command to generate the code coverage
-          # and asserting on the values of the summary report.
+  #         # Check that the code coverage worked as expected.
+  #         # The check is done by running the command to generate the code coverage
+  #         # and asserting on the values of the summary report.
 
-          npm run coverage:report | Tee-Object -Variable coverageSummary
+  #         npm run coverage:report | Tee-Object -Variable coverageSummary
 
-          $expectedStatements = $false
-          $expectedBranches = $false
-          $expectedFunctions = $false
-          $expectedLines = $false
+  #         $expectedStatements = $false
+  #         $expectedBranches = $false
+  #         $expectedFunctions = $false
+  #         $expectedLines = $false
 
-          foreach($coverageLine in $coverageSummary)
-          {
-            if($coverageLine.Contains("Statements   : 88.88% ( 8/9 )"))
-            {
-              $expectedStatements = $true
-            }
-            elseif($coverageLine.Contains("Branches     : 100% ( 2/2 )"))
-            {
-              $expectedBranches = $true
-            }
-            elseif($coverageLine.Contains("Functions    : 50% ( 1/2 )"))
-            {
-              $expectedFunctions = $true
-            }
-            elseif($coverageLine.Contains("Lines        : 100% ( 8/8 )"))
-            {
-              $expectedLines = $true
-            }
-          }
+  #         foreach($coverageLine in $coverageSummary)
+  #         {
+  #           if($coverageLine.Contains("Statements   : 88.88% ( 8/9 )"))
+  #           {
+  #             $expectedStatements = $true
+  #           }
+  #           elseif($coverageLine.Contains("Branches     : 100% ( 2/2 )"))
+  #           {
+  #             $expectedBranches = $true
+  #           }
+  #           elseif($coverageLine.Contains("Functions    : 50% ( 1/2 )"))
+  #           {
+  #             $expectedFunctions = $true
+  #           }
+  #           elseif($coverageLine.Contains("Lines        : 100% ( 8/8 )"))
+  #           {
+  #             $expectedLines = $true
+  #           }
+  #         }
 
-          if(!$expectedStatements -OR !$expectedBranches -OR !$expectedFunctions -OR !$expectedLines)
-          {
-            Write-Output "::error::Failed running the code-coverage-with-istanbul-via-webpack-babel-plugin demo. Code coverage summary is different from what is expected."
-            Exit 1
-          }
+  #         if(!$expectedStatements -OR !$expectedBranches -OR !$expectedFunctions -OR !$expectedLines)
+  #         {
+  #           Write-Output "::error::Failed running the code-coverage-with-istanbul-via-webpack-babel-plugin demo. Code coverage summary is different from what is expected."
+  #           Exit 1
+  #         }
 
-          Exit 0
-  code-coverage-with-monocart-reporter:
-    name: code-coverage-with-monocart-reporter demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: code-coverage-with-monocart-reporter demo
-      run: |
-          cd "${{ github.workspace }}/demos/code-coverage-with-monocart-reporter"
-          npm ci
-          npx playwright install --with-deps
-          npm test | Tee-Object -Variable testOutput
+  #         Exit 0
+  # code-coverage-with-monocart-reporter:
+  #   name: code-coverage-with-monocart-reporter demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: code-coverage-with-monocart-reporter demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/code-coverage-with-monocart-reporter"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test | Tee-Object -Variable testOutput
 
-          # Check that the code coverage worked as expected.
-          # The check is done by asserting on the values of the summary report and
-          # veryfing that the expected coverage report files were created
+  #         # Check that the code coverage worked as expected.
+  #         # The check is done by asserting on the values of the summary report and
+  #         # veryfing that the expected coverage report files were created
 
-          $expectedLines = $false
+  #         $expectedLines = $false
 
-          foreach($testLine in $testOutput)
-          {
-            if($testLine.Contains("99.72 %"))
-            {
-              $expectedLines = $true
-            }
-          }
+  #         foreach($testLine in $testOutput)
+  #         {
+  #           if($testLine.Contains("99.72 %"))
+  #           {
+  #             $expectedLines = $true
+  #           }
+  #         }
 
-          if(!$expectedLines)
-          {
-            Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Code coverage summary is different from what is expected."
-            Exit 1
-          }
+  #         if(!$expectedLines)
+  #         {
+  #           Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Code coverage summary is different from what is expected."
+  #           Exit 1
+  #         }
 
-          $cobertura = Test-Path ./test-results/code-coverage/cobertura/code-coverage.cobertura.xml -PathType Leaf
-          $v8Report = Test-Path ./test-results/code-coverage/v8/index.html -PathType Leaf
-          $htmlSpaReport = Test-Path ./test-results/code-coverage/html-spa/index.html -PathType Leaf
-          $lcovReport = Test-Path ./test-results/code-coverage/lcov/code-coverage.lcov.info -PathType Leaf
+  #         $cobertura = Test-Path ./test-results/code-coverage/cobertura/code-coverage.cobertura.xml -PathType Leaf
+  #         $v8Report = Test-Path ./test-results/code-coverage/v8/index.html -PathType Leaf
+  #         $htmlSpaReport = Test-Path ./test-results/code-coverage/html-spa/index.html -PathType Leaf
+  #         $lcovReport = Test-Path ./test-results/code-coverage/lcov/code-coverage.lcov.info -PathType Leaf
 
-          if(!$cobertura -OR !$v8Report -OR !$htmlSpaReport -OR !$lcovReport)
-          {
-            Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Expected 4 reports but at least one is missing."
-            Exit 1
-          }
+  #         if(!$cobertura -OR !$v8Report -OR !$htmlSpaReport -OR !$lcovReport)
+  #         {
+  #           Write-Output "::error::Failed running the code-coverage-with-monocart-reporter demo. Expected 4 reports but at least one is missing."
+  #           Exit 1
+  #         }
 
-          Exit 0
-  docker:
-    name: docker demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: docker demo
-      run: |
-          cd "${{ github.workspace }}/demos/docker"
-          npm ci
-          npm test
+  #         Exit 0
+  # docker:
+  #   name: docker demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: docker demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/docker"
+  #         npm ci
+  #         npm test
 
-          # The docker demo has many options in the powershell script which are not tested.
-          # For now it will require manual testing on the docker demo powershell scripts to
-          # make sure everything is working as expected.
-  fixtures:
-    name: fixtures demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: fixtures demo
-      run: |
-          cd "${{ github.workspace }}/demos/fixtures"
-          npm ci
-          npx playwright install --with-deps
-          npm test | Tee-Object -Variable testOutput
+  #         # The docker demo has many options in the powershell script which are not tested.
+  #         # For now it will require manual testing on the docker demo powershell scripts to
+  #         # make sure everything is working as expected.
+  # fixtures:
+  #   name: fixtures demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: fixtures demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/fixtures"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test | Tee-Object -Variable testOutput
 
-          # Check that all is as expected. Should have 9 failed, 1 skipped and
-          # 8 passed tests.
+  #         # Check that all is as expected. Should have 9 failed, 1 skipped and
+  #         # 8 passed tests.
 
-          $expectedFailed = $false
-          $expectedSkipped = $false
-          $expectedPassed = $false
+  #         $expectedFailed = $false
+  #         $expectedSkipped = $false
+  #         $expectedPassed = $false
 
-          foreach($outputLine in $testOutput)
-          {
-            if($outputLine.Contains("9 failed"))
-            {
-              $expectedFailed = $true
-            }
-            elseif($outputLine.Contains("1 skipped"))
-            {
-              $expectedSkipped = $true
-            }
-            elseif($outputLine.Contains("8 passed"))
-            {
-              $expectedPassed = $true
-            }
-          }
+  #         foreach($outputLine in $testOutput)
+  #         {
+  #           if($outputLine.Contains("9 failed"))
+  #           {
+  #             $expectedFailed = $true
+  #           }
+  #           elseif($outputLine.Contains("1 skipped"))
+  #           {
+  #             $expectedSkipped = $true
+  #           }
+  #           elseif($outputLine.Contains("8 passed"))
+  #           {
+  #             $expectedPassed = $true
+  #           }
+  #         }
 
-          if(!$expectedFailed -OR !$expectedSkipped -OR !$expectedPassed)
-          {
-            Write-Output "expectedFailed=$expectedFailed"
-            Write-Output "expectedSkipped=$expectedSkipped"
-            Write-Output "expectedPassed=$expectedPassed"
-            Write-Output "::error::Failed running the fixtures demo tests. Expected 9 failed, 1 skipped and 8 passed tests."
-            Exit 1
-          }
+  #         if(!$expectedFailed -OR !$expectedSkipped -OR !$expectedPassed)
+  #         {
+  #           Write-Output "expectedFailed=$expectedFailed"
+  #           Write-Output "expectedSkipped=$expectedSkipped"
+  #           Write-Output "expectedPassed=$expectedPassed"
+  #           Write-Output "::error::Failed running the fixtures demo tests. Expected 9 failed, 1 skipped and 8 passed tests."
+  #           Exit 1
+  #         }
 
-          Exit 0
-  monocart-reporter-advanced-config:
-    name: monocart-reporter-advanced-config demo
-    needs: [checkout-repo]
-    permissions:
-      contents: read
-    runs-on: windows-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: monocart-reporter-advanced-config demo
-      run: |
-          cd "${{ github.workspace }}/demos/monocart-reporter-advanced-config"
-          npm ci
-          npx playwright install --with-deps
-          npm test
+  #         Exit 0
+  # monocart-reporter-advanced-config:
+  #   name: monocart-reporter-advanced-config demo
+  #   needs: [checkout-repo]
+  #   permissions:
+  #     contents: read
+  #   runs-on: windows-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: monocart-reporter-advanced-config demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/monocart-reporter-advanced-config"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test
 
-          # There's no easy way to test that this demo is working as expected.
-          # For now this demo relies on manual testing to make sure everything
-          # is working.
-  stale-screenshots-cleanup:
-    name: stale-screenshots-cleanup demo
-    needs: [checkout-repo]
-    permissions: write-all
-    runs-on: windows-latest
-    steps:
-    - name: Download repo from workflow artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.REPO_ARTIFACT_NAME }}
-    - name: stale-screenshots-cleanup demo
-      run: |
-          cd "${{ github.workspace }}/demos/stale-screenshots-cleanup"
-          npm ci
-          npx playwright install --with-deps
-          npm test
+  #         # There's no easy way to test that this demo is working as expected.
+  #         # For now this demo relies on manual testing to make sure everything
+  #         # is working.
+  # stale-screenshots-cleanup:
+  #   name: stale-screenshots-cleanup demo
+  #   needs: [checkout-repo]
+  #   permissions: write-all
+  #   runs-on: windows-latest
+  #   steps:
+  #   - name: Download repo from workflow artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: ${{ env.REPO_ARTIFACT_NAME }}
+  #   - name: stale-screenshots-cleanup demo
+  #     run: |
+  #         cd "${{ github.workspace }}/demos/stale-screenshots-cleanup"
+  #         npm ci
+  #         npx playwright install --with-deps
+  #         npm test
 
-          # There's no easy way to test that this demo is working as expected.
-          # For now this demo relies on manual testing to make sure everything
-          # is working.
+  #         # There's no easy way to test that this demo is working as expected.
+  #         # For now this demo relies on manual testing to make sure everything
+  #         # is working.
   delete-repo-artifact:
     name: Delete repo artifact
     needs: [
       checkout-repo,
       accessibility-axe, 
-      accessibility-lighthouse, 
-      code-coverage-with-istanbul-via-webpack-babel-plugin,
-      code-coverage-with-monocart-reporter,
-      docker,
-      fixtures,
-      monocart-reporter-advanced-config,
-      stale-screenshots-cleanup,
+      # accessibility-lighthouse, 
+      # code-coverage-with-istanbul-via-webpack-babel-plugin,
+      # code-coverage-with-monocart-reporter,
+      # docker,
+      # fixtures,
+      # monocart-reporter-advanced-config,
+      # stale-screenshots-cleanup,
     ]
     permissions:
-      contents: read
+      actions: write
+      checks: write
+      contents: write
+      deployments: write
+      id-token: write
+      issues: write
+      discussions: write
+      packages: write
+      pages: write
+      pull-requests: write
+      repository-projects: write
+      security-events: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
     - name: Delete repo artifact


### PR DESCRIPTION
On GitHub I'm charged for Git LFS storage and bandwidth. This demo pipeline was cloning the repo multiple times, some of them using LFS set to true.

To minimize Git LFS bandwidth usage, I've decided to clone the repo once, upload it to the workflow artifacts, download the repo from artifacts on each subsequent job and then at the end delete the repo artifact.