### PR TITLE
use expect.toPass to fix flaky test

### DIFF
--- a/demos/fixtures/tests/example.spec.ts
+++ b/demos/fixtures/tests/example.spec.ts
@@ -48,7 +48,7 @@ test("consoleMessages and failOnUnexpectedConsoleMessages", async ({
   // I think it's because the assert happens before the on('console') event handler
   // from demos/fixtures/tests/_shared/fixtures/console-messages.ts is processed.
   // To make this test reliable I'm using expect.toPass to retry the assertion
-  // until it's successfull.
+  // until it's successful.
   //
   // See https://playwright.dev/docs/test-assertions#expecttopass.
   // Could also use expect.poll https://playwright.dev/docs/test-assertions#expectpoll

--- a/demos/fixtures/tests/example.spec.ts
+++ b/demos/fixtures/tests/example.spec.ts
@@ -5,32 +5,6 @@
 import { PlaywrightProjectName } from "playwright.config";
 import { expect, test } from "tests/_shared/app-fixtures";
 
-function waitForEventHandlerAsync() {
-  // See https://stackoverflow.com/questions/44741102/how-to-make-jest-wait-for-all-asynchronous-code-to-finish-execution-before-expec
-  //
-  // On webkit, sometimes the assert on the consoleMessages fixture length fails.
-  // I think it's because the assert happens before the on('console') event handler
-  // from demos/fixtures/tests/_shared/fixtures/console-messages.ts is processed.
-  //
-  // `process.nextTick()` adds callback to the "next tick queue". This queue is fully drained after the current
-  // operation on the JavaScript stack runs to completion and before the event loop is allowed to continue.
-  //
-  // This is a small hack so that we can assert things have changed as a result of handling an event from the
-  // page.on('close) event. Without this, what we would need to do is have an assert loop in the test that checks
-  // if what you want to assert has happened (for instance a property changed value), and when the assert passes
-  // (for instance property changed to expected value) it exits the assert loop and the test passes. This assert
-  // loop would also have to have a timeout so that the test doesn't stay on the assert loop forever.
-  //
-  // I've also tried to use 'await page.waitForEvent("console");' but then what happens is that most of the time
-  // the console event is processed before this statement which means that then it times out waiting for an event
-  // that already happened.
-  //
-  // UPDATE: even with this sometimes the assert on the consoleMessages fixture length fails on webkit.
-  // Not sure how much this is alleviating the problem. Keeping it for now but might switch to using a loop
-  // with timeout on the assert of the consoleMessages fixture length.
-  return new Promise(process.nextTick);
-}
-
 // This test shows the `setDate` fixture.
 // See demos\fixtures\tests\_shared\fixtures\set-date.ts.
 //
@@ -65,8 +39,22 @@ test("consoleMessages and failOnUnexpectedConsoleMessages", async ({
   consoleMessages,
 }) => {
   await page.goto("/");
-  await waitForEventHandlerAsync();
-  expect(consoleMessages.length).toBe(1);
+
+  // On webkit, sometimes the assert on the consoleMessages fixture length fails
+  // if it's done only as:
+  //
+  // expect(consoleMessages.length).toBe(1);
+  //
+  // I think it's because the assert happens before the on('console') event handler
+  // from demos/fixtures/tests/_shared/fixtures/console-messages.ts is processed.
+  // To make this test reliable I'm using expect.toPass to retry the assertion
+  // until it's successfull.
+  //
+  // See https://playwright.dev/docs/test-assertions#expecttopass.
+  // Could also use expect.poll https://playwright.dev/docs/test-assertions#expectpoll
+  await expect(async () => {
+    expect(consoleMessages.length).toBe(1);
+  }).toPass();
   expect(consoleMessages[0].text()).toBe(
     "This is an expected console message.",
   );


### PR DESCRIPTION
The `consoleMessages and failOnUnexpectedConsoleMessages` test sometimes would fail the assert on the `consoleMessages` fixture length when running on `webkit`:

```ts
expect(consoleMessages.length).toBe(1);
```

I think it's because the assert happens before the on('console') event handler from `demos/fixtures/tests/_shared/fixtures/console-messages.ts` is processed.

To make this test reliable I'm using [expect.toPass](https://playwright.dev/docs/test-assertions#expecttopass) to retry the assertion until it's successful.

Could also use [expect.poll](https://playwright.dev/docs/test-assertions#expectpoll). 
Related to [Auto-retrying assertions](https://playwright.dev/docs/test-assertions#auto-retrying-assertions) vs [Non-retrying assertions](https://playwright.dev/docs/test-assertions#non-retrying-assertions).