### PR TITLE
Update monocart-reporter-advanced-config demo to use `customFieldsInComments`

### DIFF
--- a/demos/monocart-reporter-advanced-config/package-lock.json
+++ b/demos/monocart-reporter-advanced-config/package-lock.json
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.7.tgz",
-      "integrity": "sha512-6AMnjCoC8wjqBzDHkuqpa7jAKwvMo4dC+lr/TFBz+ucfulO1XMpDnwWPGBNwClOKZ8h6xn5N81W/R5OrcKtCbQ==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -1381,16 +1381,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
-      "integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
+      "integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-replace-supers": "^7.22.20",
         "@babel/helper-split-export-declaration": "^7.22.6",
@@ -3691,9 +3690,9 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
-      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.4.tgz",
+      "integrity": "sha512-nr6/WezNzuYUppzXRaYu/W4aT5rLxdXqEFupbh6e/ovlYFQ8hpu1UUPV3Ir/YTl+74iXl2ZOMlGzudh9ZPUchQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
@@ -3744,9 +3743,9 @@
       }
     },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
-      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.1.tgz",
+      "integrity": "sha512-P4KkF9jX3y+7yFUxgcUdDtLy+t4OlDGuEBLNs57AZsfSfg+uV6MLndqGpnl4831ggaEdXwR50XFoZP4VFtHolg==",
       "dev": true,
       "dependencies": {
         "which": "^4.0.0"
@@ -3756,9 +3755,9 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-7.0.2.tgz",
-      "integrity": "sha512-Omu0rpA8WXvcGeY6DDzyRoY1i5DkCBkzyJ+m2u7PD6quzb0TvSqdIPOkTn8ZBOj7LbbcbMfZ3c5skwSu6m8y2w==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-7.0.3.tgz",
+      "integrity": "sha512-ZMWGLHpzMq3rBGIwPyeaoaleaLMvrBrH8nugHxTi5ACkJZXTxXPtVuEH91ifgtss5hUwJQ2VDnzDBWPmz78rvg==",
       "dev": true,
       "dependencies": {
         "@npmcli/node-gyp": "^3.0.0",
@@ -4835,9 +4834,9 @@
       }
     },
     "node_modules/bonjour-service": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.0.tgz",
-      "integrity": "sha512-xdzMA6JGckxyJzZByjEWRcfKmDxXaGXZWVftah3FkCqdlePNS9DjHSUN5zkP4oEfz/t0EXXlro88EIhzwMB4zA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
+      "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5185,9 +5184,9 @@
       }
     },
     "node_modules/cacache": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.1.tgz",
-      "integrity": "sha512-g4Uf2CFZPaxtJKre6qr4zqLDOOPU7bNVhWjlNhvzc51xaTOx2noMOLhfFkTAqwtrAZAKQUuDfyjitzilpA8WsQ==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
+      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
       "dev": true,
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
@@ -5262,9 +5261,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001572",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
-      "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "dev": true,
       "funding": [
         {
@@ -6354,9 +6353,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.617",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.617.tgz",
-      "integrity": "sha512-sYNE3QxcDS4ANW1k4S/wWYMXjCVcFSOX3Bg8jpuMFaXt/x8JCmp0R1Xe1ZXDX4WXnSRBf+GJ/3eGWicUuQq5cg==",
+      "version": "1.4.625",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
+      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -9569,9 +9568,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
-      "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -9608,6 +9607,21 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -9677,9 +9691,9 @@
       }
     },
     "node_modules/npm-packlist": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.1.tgz",
-      "integrity": "sha512-MQpL27ZrsJQ2kiAuQPpZb5LtJwydNRnI15QWXsf3WHERu4rzjRj6Zju/My2fov7tLuu3Gle/uoIX/DDZ3u4O4Q==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
+      "integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
       "dev": true,
       "dependencies": {
         "ignore-walk": "^6.0.4"
@@ -9887,9 +9901,9 @@
       }
     },
     "node_modules/open-cli/node_modules/open": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.0.2.tgz",
-      "integrity": "sha512-GnYLdE+E3K8NeSE23N0g67/9q9AXRph5oTUbz6IbIgElPigEnQ2aHuqRge3y0JUr67qoc84xME5kF03fDc3fcA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.0.3.tgz",
+      "integrity": "sha512-dtbI5oW7987hwC9qjJTyABldTaa19SuyJse1QboWv3b0qCcrrLNVDqBx1XgELAjh9QTVQaP/C5b1nhQebd1H2A==",
       "dev": true,
       "dependencies": {
         "default-browser": "^5.2.1",
@@ -10879,21 +10893,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/read-package-json/node_modules/normalize-package-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -11608,9 +11607,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -11857,9 +11856,9 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-      "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.3.tgz",
+      "integrity": "sha512-SE+UIQXBQE+GPG2oszWMlsEmWtHVqw/h1VrYJGK5/MC7CH5p58N448HwIrtREcvR4jfdOJAY4ieQfxMr55qbbw==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
@@ -11884,9 +11883,9 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
-      "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.3.tgz",
+      "integrity": "sha512-nU+ywttCyBitXIl9Xe0RSEfek4LneYkJxCeNnKCuhwoH4jGXO1ipIUw/VA/+Vvv2G1MTym11fzFC0SxkrcfXDw==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/demos/monocart-reporter-advanced-config/package.json
+++ b/demos/monocart-reporter-advanced-config/package.json
@@ -5,7 +5,6 @@
     "start": "npx ng serve -o",
     "test": "npx playwright test",
     "test:show-report": "npx monocart show-report ./test-results/monocart-report.html",
-    "coverage:show-report": "open-cli ./test-results/code-coverage/v8/index.html",
     "prettier:check": "npx prettier --check .",
     "prettier:write": "npx prettier --write ."
   },

--- a/demos/monocart-reporter-advanced-config/playwright.monocart-reporter.ts
+++ b/demos/monocart-reporter-advanced-config/playwright.monocart-reporter.ts
@@ -22,13 +22,15 @@ export function getMonocartReporterOptions(
         background: "#009933",
       },
     },
+    customFieldsInComments: true,
     columns: (defaultColumns: any) => {
       // See https://github.com/cenfun/monocart-reporter#custom-columns
       //
-      // Need to define a custom column that will be used to map the data collected from the visitor
-      // function defined below.
-      // Because the visitor function is collectng test comments and the test comments only contain
-      // the @description comment item, I only need to define a single column with id 'description'.
+      // Need to define a custom column that will be used to map the data collected from the
+      // `customFieldsInComments: true` option defined above.
+      // Because the test comments at demos/monocart-reporter-advanced-config/tests/example.spec.ts
+      // only contain the @description comment item, I only need to define a single column with id
+      // 'description'.
       //
       // If the tests used multiple comment items, such as @description and @owner, then I would have
       // to also define a custom column with id of 'owner' to map its values to the report.
@@ -51,32 +53,6 @@ export function getMonocartReporterOptions(
             "font-weight": "normal",
           },
         });
-      }
-    },
-    visitor: (data: any, metadata: any, collect: any) => {
-      // See https://github.com/cenfun/monocart-reporter#collect-data-from-the-comments
-      //
-      // This implementation of the visitor function will analyze all test comments and
-      // collect comment items that start with '@'.
-      //
-      // The tests on this demo app only have a single comment item: '@description'. Therefore,
-      // this function will collect the comments from '@description' and save them in the data
-      // object, with the key 'description'.
-      // This means that the 'data.description' can be accessed in other parts of the report,
-      // such as by custom columns. Custom columns can pick up their values from the data
-      // object. For instance, defining a custom column with id of 'description' will pick up
-      // the values of the test comments that use the @description comment item.
-      //
-      // You can define multiple comment items in a single comment. For instance, you could
-      // define @description and @owner and have those two values added to the data object.
-
-      const parserOptions = {
-        sourceType: "module",
-        plugins: ["typescript"],
-      };
-      const comments = collect.comments(parserOptions);
-      if (comments && Object.keys(comments).length > 0) {
-        Object.assign(data, comments);
       }
     },
   };


### PR DESCRIPTION
Updated the demo to use the new `customFieldsInComments` option available on version `2.2.0` of  `monocart-reporter`. 

> (Breaking) new option customFieldsInComments: true/false instead of calling API collect.comments(parserOptions) in visitor. Migration:
```ts
{
  customFieldsInComments: true,

  /* remove following, no need anymore
  visitor: (data, metadata, collect) => {
    const parserOptions = {
    };
    const comments = collect.comments(parserOptions);
    if (comments) {
        Object.assign(data, comments);
    }
  }
  */
}
```