### PR TITLE
Add CHOKIDAR_USEPOLLING variable to Playwright tests running on Docker with UI mode

### DIFF
--- a/demos/docker/npm-pwsh-scripts/playwright.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright.ps1
@@ -160,7 +160,8 @@ function StartPlaywrightUI() {
     $startCommand = "/bin/bash -c 'npm ci && $startCommand'" # see https://stackoverflow.com/questions/28490874/docker-run-image-multiple-commands
   }
 
-  $dockerRunCommand = "docker run -it --rm --ipc=host $useHostWebServerOption $fileChangesDetectionSupportedEnv --workdir=/app -p ${uiPort}:${uiPort} -v '${PWD}:/app' $nodeModulesMount mcr.microsoft.com/playwright:v$playwrightVersion-jammy $startCommand"
+  # Setting CHOKIDAR_USEPOLLING env variable is required to get the Playwright UI to automatically refresh when tests are updated/added/removed. For more info see https://github.com/microsoft/playwright/issues/29785
+  $dockerRunCommand = "docker run -it --rm --ipc=host --env CHOKIDAR_USEPOLLING=1 $useHostWebServerOption $fileChangesDetectionSupportedEnv --workdir=/app -p ${uiPort}:${uiPort} -v '${PWD}:/app' $nodeModulesMount mcr.microsoft.com/playwright:v$playwrightVersion-jammy $startCommand"
   if ($installNpmPackages) {
     Write-Host "NPM packages will be installed in the docker container." -ForegroundColor Cyan
   }


### PR DESCRIPTION
Without using `CHOKIDAR_USEPOLLING` env variable the list of tests in the UI mode won't automatically refresh when tests are updated/added/removed. 

This is a temporary workaround until there's official support from Playwright to resolve the issue. See microsoft/playwright#29785