### PR TITLE
Review Docker demo

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -11,6 +11,10 @@
     {
       "pattern": "^http://127.0.0.1*",
       "description": "Ignore references to localhost."
+    },
+    {
+      "pattern": "^http://localhost*",
+      "description": "Ignore references to localhost."
     }
   ],
   "replacementPatterns": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,8 @@
     "tsconfig.json": "tsconfig.*.json",
     "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml",
     ".prettierrc": ".prettierrc, .prettierignore",
-    "environment.ts": "environment.*.ts"
+    "environment.ts": "environment.*.ts",
+    "docker-compose.yml": "docker-compose.*.yml",
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
 }

--- a/demos/docker/.vscode/settings.json
+++ b/demos/docker/.vscode/settings.json
@@ -10,7 +10,8 @@
     "tsconfig.json": "tsconfig.*.json",
     "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml",
     ".prettierrc": ".prettierrc, .prettierignore",
-    "environment.ts": "environment.*.ts"
+    "environment.ts": "environment.*.ts",
+    "docker-compose.yml": "docker-compose.*.yml",
   },
   "typescript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/demos/docker/.vscode/settings.json
+++ b/demos/docker/.vscode/settings.json
@@ -11,7 +11,7 @@
     "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml",
     ".prettierrc": ".prettierrc, .prettierignore",
     "environment.ts": "environment.*.ts",
-    "docker-compose.yml": "docker-compose.*.yml",
+    "docker-compose.yml": "docker-compose.*.yml"
   },
   "typescript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/demos/docker/.vscode/tasks.json
+++ b/demos/docker/.vscode/tasks.json
@@ -48,26 +48,26 @@
       "type": "process",
       "command": "pwsh",
       "args": [
-          // Instead of using a task with 'type' set to 'shell' and the 'command' set to the powershell script I want to invoke,
-          // here I'm using a task with 'type' set to 'process' to be able to invoke the PowerShell CLI directly, with the PowerShell
-          // code passed in these "args".
-          //
-          // This is because I need to be able to pass double quotes and not have powershell remove them and I also don't want to have
-          // to escape them. For example, if I used a task with type 'shell', when executing this task with a user input of:  --grep "load page"
-          // for the ${input:testOptions}, then the double quotes would get stripped out when invoking the playwright-vscode-task.ps1 script
-          // and what gets to the playwright-vscode-task.ps1 script is just: --grep load page
-          // which then causes it to not work as expected.
-          //
-          // One alternative is to have the user escape the double quotes when providing the value for ${input:testOptions}. The user
-          // would have to provide this value as:
-          // --grep \"load page\" or --grep """load page""" (triple quotes because this value is then passed onto another pwsh
-          // script which will also strip a set of double quotes).
-          //
-          // To avoid passing the responsability of escaping to the user I'm using a task with 'type' command.
-          // For more information see: https://stackoverflow.com/questions/77540370/how-to-keep-double-quote-in-here-string-for-powershell-in-vscode-task
-          //
-          "-Command",
-          "./npm-pwsh-scripts/playwright-vscode-task.ps1 -testOptions '${input:testOptions}' -webServerMode ${input:webServerMode} -webServerHost ${input:webServerHost} -webServerPort ${input:webServerPort}",
+        // Instead of using a task with 'type' set to 'shell' and the 'command' set to the powershell script I want to invoke,
+        // here I'm using a task with 'type' set to 'process' to be able to invoke the PowerShell CLI directly, with the PowerShell
+        // code passed in these "args".
+        //
+        // This is because I need to be able to pass double quotes and not have powershell remove them and I also don't want to have
+        // to escape them. For example, if I used a task with type 'shell', when executing this task with a user input of:  --grep "load page"
+        // for the ${input:testOptions}, then the double quotes would get stripped out when invoking the playwright-vscode-task.ps1 script
+        // and what gets to the playwright-vscode-task.ps1 script is just: --grep load page
+        // which then causes it to not work as expected.
+        //
+        // One alternative is to have the user escape the double quotes when providing the value for ${input:testOptions}. The user
+        // would have to provide this value as:
+        // --grep \"load page\" or --grep """load page""" (triple quotes because this value is then passed onto another pwsh
+        // script which will also strip a set of double quotes).
+        //
+        // To avoid passing the responsability of escaping to the user I'm using a task with 'type' command.
+        // For more information see: https://stackoverflow.com/questions/77540370/how-to-keep-double-quote-in-here-string-for-powershell-in-vscode-task
+        //
+        "-Command",
+        "./npm-pwsh-scripts/playwright-vscode-task.ps1 -testOptions '${input:testOptions}' -webServerMode ${input:webServerMode} -webServerHost ${input:webServerHost} -webServerPort ${input:webServerPort}"
       ],
       "presentation": {
         "focus": true,
@@ -85,26 +85,26 @@
       "type": "process",
       "command": "pwsh",
       "args": [
-          // Instead of using a task with 'type' set to 'shell' and the 'command' set to the powershell script I want to invoke,
-          // here I'm using a task with 'type' set to 'process' to be able to invoke the PowerShell CLI directly, with the PowerShell
-          // code passed in these "args".
-          //
-          // This is because I need to be able to pass double quotes and not have powershell remove them and I also don't want to have
-          // to escape them. For example, if I used a task with type 'shell', when executing this task with a user input of:  --grep "load page"
-          // for the ${input:testOptions}, then the double quotes would get stripped out when invoking the playwright-vscode-task.ps1 script
-          // and what gets to the playwright-vscode-task.ps1 script is just: --grep load page
-          // which then causes it to not work as expected.
-          //
-          // One alternative is to have the user escape the double quotes when providing the value for ${input:testOptions}. The user
-          // would have to provide this value as:
-          // --grep \"load page\" or --grep """load page""" (triple quotes because this value is then passed onto another pwsh
-          // script which will also strip a set of double quotes).
-          //
-          // To avoid passing the responsability of escaping to the user I'm using a task with 'type' command.
-          // For more information see: https://stackoverflow.com/questions/77540370/how-to-keep-double-quote-in-here-string-for-powershell-in-vscode-task
-          //
-          "-Command",
-          "./npm-pwsh-scripts/playwright-vscode-task.ps1 -ui -uiPort ${input:uiPort} -testOptions '${input:testOptions}' -webServerMode ${input:webServerMode} -webServerHost ${input:webServerHost} -webServerPort ${input:webServerPort} -fileChangesDetectionSupportMode ${input:fileChangesDetectionSupportMode}",
+        // Instead of using a task with 'type' set to 'shell' and the 'command' set to the powershell script I want to invoke,
+        // here I'm using a task with 'type' set to 'process' to be able to invoke the PowerShell CLI directly, with the PowerShell
+        // code passed in these "args".
+        //
+        // This is because I need to be able to pass double quotes and not have powershell remove them and I also don't want to have
+        // to escape them. For example, if I used a task with type 'shell', when executing this task with a user input of:  --grep "load page"
+        // for the ${input:testOptions}, then the double quotes would get stripped out when invoking the playwright-vscode-task.ps1 script
+        // and what gets to the playwright-vscode-task.ps1 script is just: --grep load page
+        // which then causes it to not work as expected.
+        //
+        // One alternative is to have the user escape the double quotes when providing the value for ${input:testOptions}. The user
+        // would have to provide this value as:
+        // --grep \"load page\" or --grep """load page""" (triple quotes because this value is then passed onto another pwsh
+        // script which will also strip a set of double quotes).
+        //
+        // To avoid passing the responsability of escaping to the user I'm using a task with 'type' command.
+        // For more information see: https://stackoverflow.com/questions/77540370/how-to-keep-double-quote-in-here-string-for-powershell-in-vscode-task
+        //
+        "-Command",
+        "./npm-pwsh-scripts/playwright-vscode-task.ps1 -ui -uiPort ${input:uiPort} -testOptions '${input:testOptions}' -webServerMode ${input:webServerMode} -webServerHost ${input:webServerHost} -webServerPort ${input:webServerPort} -fileChangesDetectionSupportMode ${input:fileChangesDetectionSupportMode}"
       ],
       "presentation": {
         "focus": true,
@@ -191,6 +191,6 @@
       "type": "pickString",
       "options": ["auto", "supported", "unsupported"],
       "default": "auto"
-    },
+    }
   ]
 }

--- a/demos/docker/.vscode/tasks.json
+++ b/demos/docker/.vscode/tasks.json
@@ -80,8 +80,8 @@
       "problemMatcher": []
     },
     {
-      "label": "open tests ui",
-      "detail": "Opens Playwright tests UI.",
+      "label": "run tests ui",
+      "detail": "Run Playwright tests in UI mode.",
       "type": "process",
       "command": "pwsh",
       "args": [

--- a/demos/docker/.vscode/tasks.json
+++ b/demos/docker/.vscode/tasks.json
@@ -45,8 +45,30 @@
     {
       "label": "run tests",
       "detail": "Runs the tests.",
-      "type": "shell",
-      "command": "./npm-pwsh-scripts/playwright-vscode-task.ps1 -updateSnapshots ${input:updateSnapshots} -useHostWebServer ${input:useHostWebServer} -grep '${input:grep}' -installNpmPackagesMode ${input:installNpmPackagesMode}",
+      "type": "process",
+      "command": "pwsh",
+      "args": [
+          // Instead of using a task with 'type' set to 'shell' and the 'command' set to the powershell script I want to invoke,
+          // here I'm using a task with 'type' set to 'process' to be able to invoke the PowerShell CLI directly, with the PowerShell
+          // code passed in these "args".
+          //
+          // This is because I need to be able to pass double quotes and not have powershell remove them and I also don't want to have
+          // to escape them. For example, if I used a task with type 'shell', when executing this task with a user input of:  --grep "load page"
+          // for the ${input:testOptions}, then the double quotes would get stripped out when invoking the playwright-vscode-task.ps1 script
+          // and what gets to the playwright-vscode-task.ps1 script is just: --grep load page
+          // which then causes it to not work as expected.
+          //
+          // One alternative is to have the user escape the double quotes when providing the value for ${input:testOptions}. The user
+          // would have to provide this value as:
+          // --grep \"load page\" or --grep """load page""" (triple quotes because this value is then passed onto another pwsh
+          // script which will also strip a set of double quotes).
+          //
+          // To avoid passing the responsability of escaping to the user I'm using a task with 'type' command.
+          // For more information see: https://stackoverflow.com/questions/77540370/how-to-keep-double-quote-in-here-string-for-powershell-in-vscode-task
+          //
+          "-Command",
+          "./npm-pwsh-scripts/playwright-vscode-task.ps1 -testOptions '${input:testOptions}' -webServerMode ${input:webServerMode} -webServerHost ${input:webServerHost} -webServerPort ${input:webServerPort}",
+      ],
       "presentation": {
         "focus": true,
         "panel": "dedicated"
@@ -60,8 +82,30 @@
     {
       "label": "open tests ui",
       "detail": "Opens Playwright tests UI.",
-      "type": "shell",
-      "command": "./npm-pwsh-scripts/playwright-vscode-task.ps1 -ui -uiPort ${input:uiPort} -useHostWebServer ${input:useHostWebServer} -installNpmPackagesMode ${input:installNpmPackagesMode}",
+      "type": "process",
+      "command": "pwsh",
+      "args": [
+          // Instead of using a task with 'type' set to 'shell' and the 'command' set to the powershell script I want to invoke,
+          // here I'm using a task with 'type' set to 'process' to be able to invoke the PowerShell CLI directly, with the PowerShell
+          // code passed in these "args".
+          //
+          // This is because I need to be able to pass double quotes and not have powershell remove them and I also don't want to have
+          // to escape them. For example, if I used a task with type 'shell', when executing this task with a user input of:  --grep "load page"
+          // for the ${input:testOptions}, then the double quotes would get stripped out when invoking the playwright-vscode-task.ps1 script
+          // and what gets to the playwright-vscode-task.ps1 script is just: --grep load page
+          // which then causes it to not work as expected.
+          //
+          // One alternative is to have the user escape the double quotes when providing the value for ${input:testOptions}. The user
+          // would have to provide this value as:
+          // --grep \"load page\" or --grep """load page""" (triple quotes because this value is then passed onto another pwsh
+          // script which will also strip a set of double quotes).
+          //
+          // To avoid passing the responsability of escaping to the user I'm using a task with 'type' command.
+          // For more information see: https://stackoverflow.com/questions/77540370/how-to-keep-double-quote-in-here-string-for-powershell-in-vscode-task
+          //
+          "-Command",
+          "./npm-pwsh-scripts/playwright-vscode-task.ps1 -ui -uiPort ${input:uiPort} -testOptions '${input:testOptions}' -webServerMode ${input:webServerMode} -webServerHost ${input:webServerHost} -webServerPort ${input:webServerPort} -fileChangesDetectionSupportMode ${input:fileChangesDetectionSupportMode}",
+      ],
       "presentation": {
         "focus": true,
         "panel": "dedicated"
@@ -111,72 +155,42 @@
   ],
   "inputs": [
     {
-      "id": "buildConfiguration",
-      "description": "Which Angular configuration to use?",
-      "type": "pickString",
-      "options": ["dev", "prod"],
-      "default": "dev"
-    },
-    {
-      "id": "dryRun",
-      "description": "Dry run? If true, it will only report on obsolete snapshots, nothing will be deleted.",
-      "type": "pickString",
-      "options": ["yes", "no"],
-      "default": "no"
-    },
-    {
-      "id": "updateSnapshots",
-      "description": "Do you want to update Playwright snapshots?",
-      "type": "pickString",
-      "options": ["yes", "no"],
-      "default": "no"
-    },
-    {
       "id": "uiPort",
       "description": "What port do you want to use for UI mode?",
       "type": "promptString",
       "default": "43008"
     },
     {
-      "id": "useHostWebServer",
-      "description": "Do you want to use the host's web server?",
-      "type": "pickString",
-      "options": ["yes", "no"],
-      "default": "no"
-    },
-    {
-      "id": "grep",
-      "description": "Only run tests matching this regular expression. By default all tests are executed.",
+      "id": "testOptions",
+      "description": "Extra Playwright test CLI options",
       "type": "promptString",
-      "default": "*"
+      "default": ""
     },
     {
-      "id": "installNpmPackagesMode",
-      "description": "Install NPM packages in docker container or mount the from host.",
+      "id": "webServerMode",
+      "description": "Which Playwright Web Server to use?",
       "type": "pickString",
-      "options": ["auto", "install", "mount"],
+      "options": ["auto", "from-host", "from-docker"],
       "default": "auto"
     },
     {
-      "id": "lintMode",
-      "description": "Check only or try to auto-fix ESLint errors.",
-      "type": "pickString",
-      "options": ["check", "fix"],
-      "default": "no"
+      "id": "webServerHost",
+      "description": "Host for the Playwright Web Server. Only required if 'webServerMode' was set to 'auto'.",
+      "type": "promptString",
+      "default": "127.0.0.1"
     },
     {
-      "id": "packagesMode",
-      "description": "Check only or update npm packages.",
-      "type": "pickString",
-      "options": ["check", "update"],
-      "default": "check"
+      "id": "webServerPort",
+      "description": "Port for the Playwright Web Server. Only required if 'webServerMode' was set to 'auto'.",
+      "type": "promptString",
+      "default": "4200"
     },
     {
-      "id": "prettierMode",
-      "description": "Check only or update code formatting violations.",
+      "id": "fileChangesDetectionSupportMode",
+      "description": "Whether the Docker container supports file changes detection automatically or not.",
       "type": "pickString",
-      "options": ["check", "update"],
-      "default": "check"
-    }
+      "options": ["auto", "supported", "unsupported"],
+      "default": "auto"
+    },
   ]
 }

--- a/demos/docker/README.md
+++ b/demos/docker/README.md
@@ -134,7 +134,6 @@ npm test '--' -testOptions '--update-snapshots --grep "load page"' -webServerMod
 > [!NOTE]
 >
 > On the example `npm` command above you only need the single quotes around the double dash if you're running the `npm` command from Powershell. For more info see [Powershell and passing command line arguments to npm commands](#powershell-and-passing-command-line-arguments-to-npm-commands)
->
 
 ### Docker compose file
 
@@ -148,12 +147,11 @@ The [docker-compose.yml](/demos/docker/docker-compose.yml) file requires the fol
 | NPM_INSTALL_COMMAND       | NPM command to install packages. Usually `npm i` if NOT running in a CI environment and `npm ci` when running on a CI environment.                                                                                                                                                                        | npm i         | no       |
 | USE_DOCKER_HOST_WEBSERVER | Determines if the Playwright tests should be executed against the [Playwright Web Server](https://playwright.dev/docs/test-webserver) running on the host or inside Docker. If you have the target test application running outside of Docker you can set this to `true`, otherwise it should be `false`. | false         | no       |
 
-
 If you want to run the `docker compose up` command without the pwsh script then you can do so by:
 
-1) Go to /demos/docker.
-2) Set the required environment variables (see example below).
-3) Run `docker compose up`.
+1. Go to /demos/docker.
+2. Set the required environment variables (see example below).
+3. Run `docker compose up`.
 
 To set environment variables for the `docker compose up` command you can either create a `.env` file at `/demos/docker` and populate it. For instance:
 
@@ -260,7 +258,6 @@ npm run test:ui '--' -testOptions '--grep "load page"' -webServerMode from-docke
 > [!NOTE]
 >
 > On the example `npm` command above you only need the single quotes around the double dash if you're running the `npm` command from Powershell. For more info see [Powershell and passing command line arguments to npm commands](#powershell-and-passing-command-line-arguments-to-npm-commands)
->
 
 ### Docker compose file
 
@@ -279,9 +276,9 @@ The [docker-compose.ui.yml](/demos/docker/docker-compose.ui.yml) file requires t
 
 If you want to run the `docker compose up` command without the pwsh script then you can do so by:
 
-1) Go to /demos/docker.
-2) Set the required environment variables (see example below).
-3) Run `docker compose -f ./docker-compose.ui.yml up`.
+1. Go to /demos/docker.
+2. Set the required environment variables (see example below).
+3. Run `docker compose -f ./docker-compose.ui.yml up`.
 
 To set environment variables for the `docker compose up` command you can either create a `.env` file at `/demos/docker` and populate it. For instance:
 

--- a/demos/docker/README.md
+++ b/demos/docker/README.md
@@ -26,8 +26,8 @@
   - [Powershell and passing command line arguments to npm commands](#powershell-and-passing-command-line-arguments-to-npm-commands)
 - [Bonus: Visual Studio Code integration](#bonus-visual-studio-code-integration)
   - [Example running the tests using the Visual Studio Code task](#example-running-the-tests-using-the-visual-studio-code-task)
-  - [Example running the tests using the Visual Studio task and setting `useHostWebServer` to `yes`](#example-running-the-tests-using-the-visual-studio-task-and-setting-usehostwebserver-to-yes)
   - [Example running the tests in UI mode using the Visual Studio Code task](#example-running-the-tests-in-ui-mode-using-the-visual-studio-code-task)
+  - [Example running the app and then the tests using the Visual Studio tasks](#example-running-the-app-and-then-the-tests-using-the-visual-studio-tasks)
   - [Example debugging the app using Visual Studio Code](#example-debugging-the-app-using-visual-studio-code)
 
 ## Description
@@ -337,7 +337,7 @@ The main changes are:
 2. Updated the `reporter` array. In addition to using the [default html reporter](https://playwright.dev/docs/test-reporters#html-reporter), we've added the [built-in list reporter](https://playwright.dev/docs/test-reporters#list-reporter).
 3. Defined a [baseURL](https://playwright.dev/docs/test-webserver#adding-a-baseurl) so that we can use relative URLs when doing page navigations on the tests.
 4. Configured the `webServer` block to run the Angular app locally so that the tests can be executed against it. If you're not testing an Angular app that's fine, you just need to adjust the `webServer.command` so that it launches your app and set the `webServer.url` to the url your app will be running at. For more information see the [webServer docs](https://playwright.dev/docs/test-webserver).
-5. Defined the `snapshotPathTemplate` option to group snapshots by Operating System. This is a choice for this demo, it's not mandatory. This options is configured so that all snapshots generated on Unix will be stored at `/tests/__screenshots__/linux` and all snapshots generated on Windows will be storted at `/tests/__screenshots__/win32`. One of the reasons this is done is so that we can add the windows directory to the [.gitignore](/demos/docker/.gitignore) to avoid committing windows snapshots in case someone runs the tests outside of Docker for any reason. Remember that the whole point of running in Docker is to generate Unix like snapshots to get consistent behavior between running locally and on CI, so you should never want to commit windows generated snapshots.
+5. Defined the `snapshotPathTemplate` option to group snapshots by Operating System. This is a choice for this demo, it's not mandatory. This options is configured so that all snapshots generated on Unix will be stored at `/tests/__screenshots__/linux` and all snapshots generated on Windows will be stored at `/tests/__screenshots__/win32`. One of the reasons this is done is so that we can add the windows directory to the [.gitignore](/demos/docker/.gitignore) to avoid committing windows snapshots in case someone runs the tests outside of Docker for any reason. Remember that the whole point of running in Docker is to generate Unix like snapshots to get consistent behavior between running locally and on CI, so you should never want to commit windows generated snapshots.
 
 > [!NOTE]
 >
@@ -524,7 +524,7 @@ The available tasks are:
 - `install packages`: installs npm packages.
 - `run app`: builds and runs the app.
 - `run tests`: runs the Playwright tests in a docker container.
-- `open tests ui`: runs the Playwright tests in a docker container using UI mode.
+- `run tests ui`: runs the Playwright tests in a docker container using UI mode.
 - `show tests report`: opens the test results report.
 
 **To get access to these tasks make sure you open the `/demos/docker/` folder in Visual Studio Code.**
@@ -535,23 +535,21 @@ The available tasks are:
 
 ### Example running the tests using the Visual Studio Code task
 
-When you run the `run tests` task you will be prompted for some input which is then passed on to the [playwright.ps1](#playwrightps1-powershell-script-details) Powershell script.
+When you run the `run tests` task you will be prompted for some input which is then passed on to the [playwright-vscode-task.ps1](/npm-pwsh-scripts/playwright-vscode-task.ps1) Powershell script.
 
 https://github.com/edumserrano/playwright-adventures/assets/15857357/204e5a7e-c098-4823-bf0e-36f240620f22
 
-### Example running the tests using the Visual Studio task and setting `useHostWebServer` to `yes`
-
-When you run the `run tests` task and choose `yes` to the `Do you want to use the host's web server?` prompt, notice that the docker container won't have to install packages nor build and run the app. It immediatly starts to run the tests against the version of the app that is running on the host.
-
-You have to run the app locally outside of docker before you choose this option.
-
-https://github.com/edumserrano/playwright-adventures/assets/15857357/f4c6bbad-ce61-4400-a1a8-3a94a32ba107
-
 ### Example running the tests in UI mode using the Visual Studio Code task
 
-When you run the `open tests ui` task you will be prompted for some input which is then passed on to the [playwright.ps1](#playwrightps1-powershell-script-details) Powershell script.
+When you run the `run tests ui` task you will be prompted for some input which is then passed on to the [playwright-vscode-task.ps1](/npm-pwsh-scripts/playwright-vscode-task.ps1) Powershell script.
 
 https://github.com/edumserrano/playwright-adventures/assets/15857357/923f30a0-27ad-4197-bb12-557c8746e688
+
+### Example running the app and then the tests using the Visual Studio tasks
+
+If you have the target test app running before you run the `run tests` task or `run tests ui` task and choose `auto` or `from-host` to the `Which Playwright Web Server to use?` prompt, notice that the docker container won't have to install packages nor build and run the app. It immediately starts to run the tests against the the target test app that is running on the host.
+
+https://github.com/edumserrano/playwright-adventures/assets/15857357/f4c6bbad-ce61-4400-a1a8-3a94a32ba107
 
 ### Example debugging the app using Visual Studio Code
 

--- a/demos/docker/README.md
+++ b/demos/docker/README.md
@@ -528,13 +528,13 @@ The available tasks are:
 
 ### Example running the tests using the Visual Studio Code task
 
-When you run the `run tests` task you will be prompted for some input which is then passed on to the [playwright-vscode-task.ps1](/npm-pwsh-scripts/playwright-vscode-task.ps1) Powershell script.
+When you run the `run tests` task you will be prompted for some input which is then passed on to the [playwright-vscode-task.ps1](/demos/docker/npm-pwsh-scripts/playwright-vscode-task.ps1) Powershell script.
 
 https://github.com/edumserrano/playwright-adventures/assets/15857357/204e5a7e-c098-4823-bf0e-36f240620f22
 
 ### Example running the tests in UI mode using the Visual Studio Code task
 
-When you run the `run tests ui` task you will be prompted for some input which is then passed on to the [playwright-vscode-task.ps1](/npm-pwsh-scripts/playwright-vscode-task.ps1) Powershell script.
+When you run the `run tests ui` task you will be prompted for some input which is then passed on to the [playwright-vscode-task.ps1](/demos/docker/npm-pwsh-scripts/playwright-vscode-task.ps1) Powershell script.
 
 https://github.com/edumserrano/playwright-adventures/assets/15857357/923f30a0-27ad-4197-bb12-557c8746e688
 

--- a/demos/docker/README.md
+++ b/demos/docker/README.md
@@ -102,19 +102,22 @@ The Docker setup to run Playwright tests uses the [docker-compose.yml](/demos/do
 
 The `npm test` can be customized with the following parameters:
 
-<div style="overflow-x:scroll; background: red" markdown="block">
 
-| pwsh parameter   | Description                                                                                                                                                                                                                                                                                               | Possible values | Default value | Example                                                |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------- | ------------------------------------------------------ |
-| `-testOptions`   | Use this to pass any [Playwright CLI supported test options](https://playwright.dev/docs/test-cli) to the `playwright test` command.                                                                                                                                                                      | Free text.      | Empty string. | `-testOptions '--update-snapshots --grep "load page"'` |
-| `-webServerMode` | Determines if the Playwright tests should be executed against the [Playwright Web Server](https://playwright.dev/docs/test-webserver) running on the host or inside Docker. If you have the target test application running outside of Docker you can set this to `from-host`, otherwise it should be `from-docker`. Using `auto` will mean that the pwsh script will attempt to decide if the target test application is running on the host and if so it will use the `from-host` option, if not it will use the `from-docker` option. Setting to `auto` requires setting the `-webServerHost` and `webServerPort` parameters. | `auto` \| `from-host` \| `from-docker`               |               |                                                        |
-| `-webServerHost` | Content Cell                                                                                                                                                                                                                                                                                              |                 |               |                                                        |
-| `-webServerPort` | Content Cell                                                                                                                                                                                                                                                                                              |                 |               |                                                        |
+| pwsh parameter   | Description  | Possible values                        | Default value | Example |
+| ---------------- | ------------ | -------------------------------------- | ------------- | ------- |
+| `-webServerMode` |              | `auto` \| `from-host` \| `from-docker` |               |         |
+| `-webServerHost` | Content Cell |                                        |               |         |
+| `-webServerPort` | Content Cell |                                        |               |         |
 
-</div>
 
-- `-testOptions`: free text, defaults to an empty string. Use this to pass any [Playwright CLI supported test options](https://playwright.dev/docs/test-cli) to the `playwright test` command. Example:
-- `-webServerMode`: one of `auto`, `from-docker` or `from-host`. Example: `-webServerMode from-docker`.
+- `-testOptions`: Use this to pass any [Playwright CLI supported test options](https://playwright.dev/docs/test-cli) to the `playwright test` command. It's a free text parameter and defaults to an empty string.
+
+  **Example:** `-testOptions '--update-snapshots --grep "load page"'`
+
+- `-webServerMode`: Determines if the Playwright tests should be executed against the [Playwright Web Server](https://playwright.dev/docs/test-webserver) running on the host or inside Docker. If you have the target test application running outside of Docker you can set this to `from-host`, otherwise it should be `from-docker`. Using `auto` will mean that the pwsh script will attempt to decide if the target test application is running on the host and if so it will use the `from-host` option, if not it will use the `from-docker` option. Setting to `auto` requires setting the `-webServerHost` and `webServerPort` parameters. one of `auto`, `from-docker` or `from-host`.
+
+  **Example**: `-webServerMode from-docker`.
+
 - `-webServerHost`: setting `-useHostWebServer` enables this option.
 - `-webServerPort`: setting `-useHostWebServer` enables this option.
 - `-updateSnapshots`: setting `-updateSnapshots` enables this option.

--- a/demos/docker/README.md
+++ b/demos/docker/README.md
@@ -543,7 +543,7 @@ https://github.com/edumserrano/playwright-adventures/assets/15857357/923f30a0-27
 
 ### Example running the app and then the tests using the Visual Studio tasks
 
-If you have the target test app running before you run the `run tests` task or `run tests ui` task and choose `auto` or `from-host` to the `Which Playwright Web Server to use?` prompt, notice that the docker container won't have to install packages nor build and run the app. It immediately starts to run the tests against the the target test app that is running on the host.
+If you have the target test app running before you run the `run tests` task or `run tests ui` task and choose `auto` or `from-host` to the `Which Playwright Web Server to use?` prompt, notice that the docker container won't have to build and run the app. Instead, it immediately starts to run the tests against the the target test app that is running on the host.
 
 https://github.com/edumserrano/playwright-adventures/assets/15857357/f4c6bbad-ce61-4400-a1a8-3a94a32ba107
 

--- a/demos/docker/docker-compose.ui.yml
+++ b/demos/docker/docker-compose.ui.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 name: playwright-ui-docker-demo
 
 include:

--- a/demos/docker/docker-compose.ui.yml
+++ b/demos/docker/docker-compose.ui.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+name: playwright-ui-docker-demo
+
+include:
+  - ./docker-compose.volumes.yml
+
+services:
+  playwright-tests-ui:
+    image: mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-jammy
+    ipc: host
+    extra_hosts:
+      - host.docker.internal:host-gateway # allows network calls between docker container and the host. See https://forums.docker.com/t/how-to-reach-localhost-on-host-from-docker-container/113321
+    working_dir: /app
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        ${NPM_INSTALL_COMMAND:-npm i}
+        npx playwright test --ui-port=${UI_PORT:-43008} --ui-host=0.0.0.0 ${PLAYWRIGHT_TEST_OPTIONS:-}
+    volumes:
+      - .:/app
+      - npm-cache:/root/.npm
+      - node-modules:/app/node_modules # exclude node_modules from the mounted /app dir. See https://www.howtogeek.com/devops/how-to-mount-a-docker-volume-while-excluding-a-subdirectory/
+    ports:
+      - ${UI_PORT:-43008}:${UI_PORT:-43008}
+    stop_grace_period: 0s
+    environment:
+      CI: ${CI:-false}
+      USE_DOCKER_HOST_WEBSERVER: ${USE_DOCKER_HOST_WEBSERVER:-false}
+      FILE_CHANGES_DETECTION_SUPPORTED: ${FILE_CHANGES_DETECTION_SUPPORTED:-false}
+      CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-true} # setting CHOKIDAR_USEPOLLING env variable might be required to get the Playwright UI to automatically refresh when tests are updated/added/removed. For more info see https://github.com/microsoft/playwright/issues/29785
+    healthcheck:
+      test: wget --no-cache --spider http://localhost:${UI_PORT:-43008}
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 1m
+      start_interval: 5s

--- a/demos/docker/docker-compose.volumes.yml
+++ b/demos/docker/docker-compose.volumes.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+name: playwright-docker-demo
+
+volumes:
+  npm-cache:
+    external: false
+  node-modules:
+    external: false

--- a/demos/docker/docker-compose.volumes.yml
+++ b/demos/docker/docker-compose.volumes.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 name: playwright-docker-demo
 
 volumes:

--- a/demos/docker/docker-compose.yml
+++ b/demos/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 name: playwright-docker-demo
 
 include:
@@ -25,4 +25,3 @@ services:
     environment:
       CI: ${CI:-false}
       USE_DOCKER_HOST_WEBSERVER: ${USE_DOCKER_HOST_WEBSERVER:-false}
-

--- a/demos/docker/docker-compose.yml
+++ b/demos/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+name: playwright-docker-demo
+
+include:
+  - ./docker-compose.volumes.yml
+
+services:
+  playwright-tests:
+    image: mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-jammy
+    ipc: host
+    extra_hosts:
+      - host.docker.internal:host-gateway # allows network calls between docker container and the host. See https://forums.docker.com/t/how-to-reach-localhost-on-host-from-docker-container/113321
+    working_dir: /app
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        ${NPM_INSTALL_COMMAND:-npm i}
+        npx playwright test ${PLAYWRIGHT_TEST_OPTIONS:-}
+    volumes:
+      - .:/app
+      - npm-cache:/root/.npm
+      - node-modules:/app/node_modules # exclude node_modules from the mounted /app dir. See https://www.howtogeek.com/devops/how-to-mount-a-docker-volume-while-excluding-a-subdirectory/
+    stop_grace_period: 0s
+    environment:
+      CI: ${CI:-false}
+      USE_DOCKER_HOST_WEBSERVER: ${USE_DOCKER_HOST_WEBSERVER:-false}
+

--- a/demos/docker/npm-pwsh-scripts/playwright-vscode-task.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright-vscode-task.ps1
@@ -6,40 +6,31 @@
 param (
   [switch] $ui = $false,
   [string] $uiPort = "43008",
-  [string] $updateSnapshots = "no",
-  [string] $useHostWebServer = "no",
-  [string] $grep = "",
-  [ValidateSet("auto", "install", "mount")]
-  [string] $installNpmPackagesMode = "auto"
+  [string] $testOptions = "",
+  [ValidateSet("auto", "from-docker", "from-host")]
+  [string] $webServerMode = "auto",
+  [string] $webServerHost = "127.0.0.1",
+  [string] $webServerPort = "4200",
+  [ValidateSet("auto", "supported", "unsupported")]
+  [string] $fileChangesDetectionSupportMode = "auto"
 )
-
-function ConvertToBool($value) {
-  return ($("False", "0", "", "N", "No", '$False', "Off") -notcontains [string]$value)
-}
 
 function StartPlaywrightTests {
   $ErrorActionPreference = 'Stop';
-  $command = "./npm-pwsh-scripts/playwright.ps1";
-
+  $command = "pwsh -NoProfile ./npm-pwsh-scripts/playwright.ps1";
   if ($ui) {
     $command += " -ui";
   }
 
   $command += " -uiPort $uiPort";
-
-  if (ConvertToBool -value $updateSnapshots) {
-    $command += " -updateSnapshots";
+  if (![string]::IsNullOrEmpty($testOptions)) {
+    $command += " -testOptions '$testOptions'"
   }
 
-  if (ConvertToBool -value $useHostWebServer) {
-    $command += " -useHostWebServer";
-  }
-
-  if (![string]::IsNullOrEmpty($grep) -and $grep -ne "*") {
-    $command += " -grep ""$grep"""
-  }
-
-  $command += " -installNpmPackagesMode $installNpmPackagesMode";
+  $command += " -webServerMode $webServerMode";
+  $command += " -webServerHost $webServerHost";
+  $command += " -webServerPort $webServerPort";
+  $command += " -fileChangesDetectionSupportMode $fileChangesDetectionSupportMode";
 
   Invoke-Expression -Command $command
   Exit $LASTEXITCODE # see https://stackoverflow.com/questions/32348794/how-to-get-status-of-invoke-expression-successful-or-failed

--- a/demos/docker/npm-pwsh-scripts/playwright.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright.ps1
@@ -92,6 +92,8 @@ function StartPlaywrightTests {
   Write-Host "-grep=$grep"  -ForegroundColor DarkYellow
   Write-Host "-installNpmPackagesMode=$installNpmPackagesMode`n" -ForegroundColor DarkYellow
 
+  docker compose config
+
   if ($updateSnapshots) {
     $updateSnapshotsOption = "--update-snapshots"
   }

--- a/demos/docker/npm-pwsh-scripts/playwright.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright.ps1
@@ -32,7 +32,7 @@ function IsFileChangesDetectionSupported() {
     $isDockerDesktopOnWindowsUsingWsl2 = IsDockerDesktopOnWindowsUsingWsl2
     if($isDockerDesktopOnWindowsUsingWsl2) {
       Write-Host "Detected Docker Desktop running on WSL2. FILE_CHANGES_DETECTION_SUPPORTED=false environment variable will be added to the docker command." -ForegroundColor Cyan
-      Write-Host ""
+      Write-Host "`n" -NoNewline
     }
 
     return !$isDockerDesktopOnWindowsUsingWsl2;
@@ -65,7 +65,7 @@ function UseHostWebServer() {
     $isWebServerUrlAlive = [System.Net.Sockets.TcpClient]::new().ConnectAsync($webServerHost, $webServerPort).Wait(500)
     if($isWebServerUrlAlive) {
       Write-Host "Playwright's target WebServer is running at ${webServerHost}:$webServerPort. USE_DOCKER_HOST_WEBSERVER=true environment variable will be added to the docker command." -ForegroundColor Cyan
-      Write-Host ""
+      Write-Host "`n" -NoNewline
     }
 
     return $isWebServerUrlAlive;
@@ -80,13 +80,13 @@ function UseHostWebServer() {
 
 function StartPlaywrightTests {
   Write-Host "Starting playwright tests run in docker container..." -ForegroundColor Cyan
-  Write-Host ""
+  Write-Host "`n" -NoNewline
   Write-Host "options:" -ForegroundColor DarkYellow
   Write-Host "-testOptions=$testOptions" -ForegroundColor DarkYellow
   Write-Host "-webServerMode=$webServerMode" -ForegroundColor DarkYellow
   Write-Host "-webServerHost=$webServerHost" -ForegroundColor DarkYellow
   Write-Host "-webServerPort=$webServerPort" -ForegroundColor DarkYellow
-  Write-Host ""
+  Write-Host "`n" -NoNewline
 
   $playwrightVersion = GetPlaywrightVersion
   $isCI = [System.Convert]::ToBoolean($env:CI)
@@ -105,18 +105,16 @@ function StartPlaywrightTests {
   Write-Host "PLAYWRIGHT_TEST_OPTIONS=$env:PLAYWRIGHT_TEST_OPTIONS" -ForegroundColor DarkYellow
   Write-Host "NPM_INSTALL_COMMAND=$env:NPM_INSTALL_COMMAND" -ForegroundColor DarkYellow
   Write-Host "USE_DOCKER_HOST_WEBSERVER=$env:USE_DOCKER_HOST_WEBSERVER" -ForegroundColor DarkYellow
-  Write-Host ""
+  Write-Host "`n" -NoNewline
 
-  Write-Host "Starting docker container..." -ForegroundColor Cyan
-  Write-Host ""
-
+  Write-Host "Starting docker container...`n" -ForegroundColor Cyan
   docker compose up --exit-code-from playwright-tests
   Exit $LASTEXITCODE # this in combination with --exit-code-from on the docker compose command above means that the exit code will match the exit code from running the playwright tests. In other words, it allows for failing a CI pipeline if the tests fail.
 }
 
 function StartPlaywrightUI() {
   Write-Host "Starting playwright tests with ui in docker container..."
-  Write-Host ""
+  Write-Host "`n" -NoNewline
   Write-Host "options:" -ForegroundColor DarkYellow
   Write-Host "-uiPort=$uiPort" -ForegroundColor DarkYellow
   Write-Host "-testOptions=$testOptions" -ForegroundColor DarkYellow
@@ -124,7 +122,7 @@ function StartPlaywrightUI() {
   Write-Host "-webServerHost=$webServerHost" -ForegroundColor DarkYellow
   Write-Host "-webServerPort=$webServerPort" -ForegroundColor DarkYellow
   Write-Host "-fileChangesDetectionSupportMode=$fileChangesDetectionSupportMode" -ForegroundColor DarkYellow
-  Write-Host ""
+  Write-Host "`n" -NoNewline
 
   $playwrightVersion = GetPlaywrightVersion
   $isCI = [System.Convert]::ToBoolean($env:CI)
@@ -150,12 +148,12 @@ function StartPlaywrightUI() {
   Write-Host "UI_PORT=$env:UI_PORT" -ForegroundColor DarkYellow
   Write-Host "FILE_CHANGES_DETECTION_SUPPORTED=$env:FILE_CHANGES_DETECTION_SUPPORTED" -ForegroundColor DarkYellow
   Write-Host "CHOKIDAR_USEPOLLING=$env:CHOKIDAR_USEPOLLING" -ForegroundColor DarkYellow
-  Write-Host ""
+  Write-Host "`n" -NoNewline
 
   Write-Host "Starting docker container with ui mode..." -ForegroundColor Cyan
   Write-Host "On success the ui mode will display a message saying: 'Listening on http://0.0.0.0:${uiPort}'." -ForegroundColor Cyan
   Write-Host "At that point you'll be able to access the test UI at http://localhost:${uiPort}" -ForegroundColor Green
-  Write-Host ""
+  Write-Host "`n" -NoNewline
 
   docker compose -f ./docker-compose.ui.yml up
 }

--- a/demos/docker/npm-pwsh-scripts/playwright.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright.ps1
@@ -32,7 +32,7 @@ function IsFileChangesDetectionSupported() {
     $isDockerDesktopOnWindowsUsingWsl2 = IsDockerDesktopOnWindowsUsingWsl2
     if($isDockerDesktopOnWindowsUsingWsl2) {
       Write-Host "Detected Docker Desktop running on WSL2. FILE_CHANGES_DETECTION_SUPPORTED=false environment variable will be added to the docker command." -ForegroundColor Cyan
-      Write-Host "`n" -NoNewline
+      Write-Host ""
     }
 
     return !$isDockerDesktopOnWindowsUsingWsl2;
@@ -65,7 +65,7 @@ function UseHostWebServer() {
     $isWebServerUrlAlive = [System.Net.Sockets.TcpClient]::new().ConnectAsync($webServerHost, $webServerPort).Wait(500)
     if($isWebServerUrlAlive) {
       Write-Host "Playwright's target WebServer is running at ${webServerHost}:$webServerPort. USE_DOCKER_HOST_WEBSERVER=true environment variable will be added to the docker command." -ForegroundColor Cyan
-      Write-Host "`n" -NoNewline
+      Write-Host ""
     }
 
     return $isWebServerUrlAlive;
@@ -80,13 +80,13 @@ function UseHostWebServer() {
 
 function StartPlaywrightTests {
   Write-Host "Starting playwright tests run in docker container..." -ForegroundColor Cyan
-  Write-Host "`n" -NoNewline
+  Write-Host ""
   Write-Host "options:" -ForegroundColor DarkYellow
   Write-Host "-testOptions=$testOptions" -ForegroundColor DarkYellow
   Write-Host "-webServerMode=$webServerMode" -ForegroundColor DarkYellow
   Write-Host "-webServerHost=$webServerHost" -ForegroundColor DarkYellow
   Write-Host "-webServerPort=$webServerPort" -ForegroundColor DarkYellow
-  Write-Host "`n" -NoNewline
+  Write-Host ""
 
   $playwrightVersion = GetPlaywrightVersion
   $isCI = [System.Convert]::ToBoolean($env:CI)
@@ -105,16 +105,18 @@ function StartPlaywrightTests {
   Write-Host "PLAYWRIGHT_TEST_OPTIONS=$env:PLAYWRIGHT_TEST_OPTIONS" -ForegroundColor DarkYellow
   Write-Host "NPM_INSTALL_COMMAND=$env:NPM_INSTALL_COMMAND" -ForegroundColor DarkYellow
   Write-Host "USE_DOCKER_HOST_WEBSERVER=$env:USE_DOCKER_HOST_WEBSERVER" -ForegroundColor DarkYellow
-  Write-Host "`n" -NoNewline
+  Write-Host ""
 
-  Write-Host "Starting docker container...`n" -ForegroundColor Cyan
+  Write-Host "Starting docker container..." -ForegroundColor Cyan
+  Write-Host ""
+
   docker compose up --exit-code-from playwright-tests
   Exit $LASTEXITCODE # this in combination with --exit-code-from on the docker compose command above means that the exit code will match the exit code from running the playwright tests. In other words, it allows for failing a CI pipeline if the tests fail.
 }
 
 function StartPlaywrightUI() {
   Write-Host "Starting playwright tests with ui in docker container..."
-  Write-Host "`n" -NoNewline
+  Write-Host ""
   Write-Host "options:" -ForegroundColor DarkYellow
   Write-Host "-uiPort=$uiPort" -ForegroundColor DarkYellow
   Write-Host "-testOptions=$testOptions" -ForegroundColor DarkYellow
@@ -122,7 +124,7 @@ function StartPlaywrightUI() {
   Write-Host "-webServerHost=$webServerHost" -ForegroundColor DarkYellow
   Write-Host "-webServerPort=$webServerPort" -ForegroundColor DarkYellow
   Write-Host "-fileChangesDetectionSupportMode=$fileChangesDetectionSupportMode" -ForegroundColor DarkYellow
-  Write-Host "`n" -NoNewline
+  Write-Host ""
 
   $playwrightVersion = GetPlaywrightVersion
   $isCI = [System.Convert]::ToBoolean($env:CI)
@@ -148,12 +150,12 @@ function StartPlaywrightUI() {
   Write-Host "UI_PORT=$env:UI_PORT" -ForegroundColor DarkYellow
   Write-Host "FILE_CHANGES_DETECTION_SUPPORTED=$env:FILE_CHANGES_DETECTION_SUPPORTED" -ForegroundColor DarkYellow
   Write-Host "CHOKIDAR_USEPOLLING=$env:CHOKIDAR_USEPOLLING" -ForegroundColor DarkYellow
-  Write-Host "`n" -NoNewline
+  Write-Host ""
 
   Write-Host "Starting docker container with ui mode..." -ForegroundColor Cyan
   Write-Host "On success the ui mode will display a message saying: 'Listening on http://0.0.0.0:${uiPort}'." -ForegroundColor Cyan
   Write-Host "At that point you'll be able to access the test UI at http://localhost:${uiPort}" -ForegroundColor Green
-  Write-Host "`n" -NoNewline
+  Write-Host ""
 
   docker compose -f ./docker-compose.ui.yml up
 }

--- a/demos/docker/npm-pwsh-scripts/playwright.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright.ps1
@@ -29,6 +29,10 @@ function GetPlaywrightVersion() {
 
 function IsFileChangesDetectionSupported() {
   if ($fileChangesDetectionSupportMode -eq "auto") {
+    if(!$IsWindows) {
+      return $true
+    }
+
     $isDockerDesktopOnWindowsUsingWsl2 = IsDockerDesktopOnWindowsUsingWsl2
     if($isDockerDesktopOnWindowsUsingWsl2) {
       Write-Host "Detected Docker Desktop running on WSL2. FILE_CHANGES_DETECTION_SUPPORTED=false environment variable will be added to the docker command." -ForegroundColor Cyan

--- a/demos/docker/package.json
+++ b/demos/docker/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "npx ng serve -o",
     "start:vscode": "npx ng serve",
-    "test": "pwsh -NoProfile -File ./npm-pwsh-scripts/playwright.ps1",
-    "test:ui": "pwsh -NoProfile -File ./npm-pwsh-scripts/playwright.ps1 -ui",
+    "test": "pwsh -NoProfile -File ./npm-pwsh-scripts/playwright.ps1 -webServerHost 127.0.0.1 -webServerPort 4200",
+    "test:ui": "pwsh -NoProfile -File ./npm-pwsh-scripts/playwright.ps1 -ui -webServerHost 127.0.0.1 -webServerPort 4200",
     "test:show-report": "npx playwright show-report ./playwright-html-report",
     "prettier:check": "npx prettier --check .",
     "prettier:write": "npx prettier --write ."

--- a/demos/docker/tests/__screenshots__/linux/chromium/example.spec.ts/some-other-test-1.png
+++ b/demos/docker/tests/__screenshots__/linux/chromium/example.spec.ts/some-other-test-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db2577ecb966616a01df6a498e361d85e8516812b837f00b3fbf6db01a49caa9
+size 36142

--- a/demos/docker/tests/__screenshots__/linux/firefox/example.spec.ts/some-other-test-1.png
+++ b/demos/docker/tests/__screenshots__/linux/firefox/example.spec.ts/some-other-test-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1ac8df93eba1fef7ee3389218f641811e93f1149b1036e3e5761e3381a31e8b
+size 54492

--- a/demos/docker/tests/__screenshots__/linux/webkit/example.spec.ts/some-other-test-1.png
+++ b/demos/docker/tests/__screenshots__/linux/webkit/example.spec.ts/some-other-test-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abd88574ce9d5ec635853779c6a1ed017266aa880df9ae1837cc16e15225c979
+size 31028

--- a/demos/docker/tests/example.spec.ts
+++ b/demos/docker/tests/example.spec.ts
@@ -4,3 +4,8 @@ test("load page", async ({ page }) => {
   await page.goto("/");
   await expect(page).toHaveScreenshot();
 });
+
+test("some other test", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveScreenshot();
+});


### PR DESCRIPTION
The previous implementation tried some workarounds to improve the start up of the container:

- allow mounting the `node_modules` from the host to avoid having to do an `npm i`. This was not always possible. In cases where the node packages had different versions depending on the OS then if you were running on a Windows OS and tried to mount the packages into the Docker container it would later fail when trying to run the app.
- the README recommended using WSL1 instead of WSL2 when using Docker for Windows and mounting the `node_modules` folder. This is because WSL1 filesystem mount is faster than WSL2 filesystem mount.

The above were far from ideal. This PR solves the issue by using named volumes for the `node_modules` and `npm cache` folders so that the start up time of the container is greatly improved because:

- you only pay the price for the `npm i` on the very first run.
- after the first run the named Docker volumes will be reused on subsequent runs (unless you manually delete them).
- this always works independent if your packages have OS specific versions because it always uses the packages installed in the named volumes.
- there are two named volumes created, one for the `npm cache` and one for `node_modules`. These two together make the `npm i` command take only a few seconds.
- when you add/remove packages to your app the `npm cache` and `node_modules` Docker volumes are updated with the delta only which is also fast.

This implementation changed the input parameters available to the user and so the README for the docker demo has been updated accordingly.

