### PR TITLE
Limit reporters when running in UI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ My experiences with Playwright focused on using it as the test tool whilst devel
 - [Should you use Git LFS when you use screenshots?](/docs/tips.md#should-you-use-git-lfs-when-you-use-screenshots)
 - [The `webServer.reuseExistingServer` configuration option](/docs/tips.md#the-webserverreuseexistingserver-configuration-option)
 - [Which reporters should I use?](/docs/tips.md#which-reporters-should-i-use)
+- [Limit reporters when running in UI mode](/docs/tips.md#limit-reporters-when-running-in-ui-mode)
 - [You might not need to run all your tests against all your projects](/docs/tips.md#you-might-not-need-to-run-all-your-tests-against-all-your-projects)
 - [Avoid using watch mode on the target test apps](/docs/tips.md#avoid-using-watch-mode-on-the-target-test-apps)
 - [What are the available devices for test projects configuration?](/docs/tips.md#what-are-the-available-devices-for-test-projects-configuration)

--- a/demos/accessibility-axe/playwright.config.ts
+++ b/demos/accessibility-axe/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -10,6 +10,28 @@ const _webServerUrl = `http://${_webServerHost}:${_webServerPort}`;
 const _webServerCommand = playwrightCliOptions.UIMode
   ? `npx ng serve --host ${_webServerHost} --port ${_webServerPort}`
   : `npx ng serve --host ${_webServerHost} --port ${_webServerPort} --watch false`;
+
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    /* See https://playwright.dev/docs/test-reporters#html-reporter */
+    [
+      "html",
+      {
+        open: "never",
+        outputFolder: path.resolve("playwright-html-report"),
+      },
+    ],
+  ];
+}
 
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
@@ -24,17 +46,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/ci#workers */
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    /* See https://playwright.dev/docs/test-reporters#html-reporter */
-    [
-      "html",
-      {
-        open: "never",
-        outputFolder: path.resolve("playwright-html-report"),
-      },
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/accessibility-axe/playwright.config.ts
+++ b/demos/accessibility-axe/playwright.config.ts
@@ -16,9 +16,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/accessibility-lighthouse/playwright.config.ts
+++ b/demos/accessibility-lighthouse/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -13,6 +13,30 @@ const _webServerCommand = playwrightCliOptions.UIMode
 
 const _testsDir = path.resolve("./tests");
 const _testResultsDir = path.resolve("./test-results");
+
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    [
+      /* See https://github.com/cenfun/monocart-reporter */
+      "monocart-reporter",
+      [
+        {
+          name: "accessibility demo with lighthouse",
+          outputFile: path.resolve(_testResultsDir, "monocart-report.html"),
+        },
+      ],
+    ],
+  ];
+}
 
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
@@ -32,19 +56,7 @@ export default defineConfig({
    */
   timeout: 1 * 60 * 1000, // 1 min
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    [
-      /* See https://github.com/cenfun/monocart-reporter */
-      "monocart-reporter",
-      [
-        {
-          name: "accessibility demo with lighthouse",
-          outputFile: path.resolve(_testResultsDir, "monocart-report.html"),
-        },
-      ],
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/accessibility-lighthouse/playwright.config.ts
+++ b/demos/accessibility-lighthouse/playwright.config.ts
@@ -19,9 +19,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/code-coverage-with-istanbul-via-webpack-babel-plugin/playwright.config.ts
+++ b/demos/code-coverage-with-istanbul-via-webpack-babel-plugin/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -11,6 +11,28 @@ const _webServerUrl = `http://${_webServerHost}:${_webServerPort}`;
 const _webServerCommand = playwrightCliOptions.UIMode
   ? `npx ng serve --host ${_webServerHost} --port ${_webServerPort}`
   : `npx ng serve --host ${_webServerHost} --port ${_webServerPort} --watch false`;
+
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    /* See https://playwright.dev/docs/test-reporters#html-reporter */
+    [
+      "html",
+      {
+        open: _isRunningOnCI ? "never" : "on-failure",
+        outputFolder: path.resolve("playwright-html-report"),
+      },
+    ],
+  ];
+}
 
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
@@ -25,17 +47,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/ci#workers */
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    /* See https://playwright.dev/docs/test-reporters#html-reporter */
-    [
-      "html",
-      {
-        open: _isRunningOnCI ? "never" : "on-failure",
-        outputFolder: path.resolve("playwright-html-report"),
-      },
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/code-coverage-with-istanbul-via-webpack-babel-plugin/playwright.config.ts
+++ b/demos/code-coverage-with-istanbul-via-webpack-babel-plugin/playwright.config.ts
@@ -17,9 +17,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/code-coverage-with-monocart-reporter/playwright.config.ts
+++ b/demos/code-coverage-with-monocart-reporter/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -16,6 +16,25 @@ const _testsDir = path.resolve("./tests");
 const _testResultsDir = path.resolve("./test-results");
 const _codeCoverageDir = path.resolve(_testResultsDir, "code-coverage");
 
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    [
+      // See https://github.com/cenfun/monocart-reporter
+      "monocart-reporter",
+      getMonocartReporterOptions(_testResultsDir, _codeCoverageDir),
+    ],
+  ];
+}
+
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
   testDir: _testsDir,
@@ -29,14 +48,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/ci#workers */
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    [
-      // See https://github.com/cenfun/monocart-reporter
-      "monocart-reporter",
-      getMonocartReporterOptions(_testResultsDir, _codeCoverageDir),
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/code-coverage-with-monocart-reporter/playwright.config.ts
+++ b/demos/code-coverage-with-monocart-reporter/playwright.config.ts
@@ -21,9 +21,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/docker/playwright.config.ts
+++ b/demos/docker/playwright.config.ts
@@ -13,7 +13,9 @@ const _webServerUrl = `http://${_webServerHost}:${_webServerPort}`;
 // For more info on the reason for the env.USE_POLL_ON_NG_SERVE see the section
 // 'File changes aren't triggering an application rebuild when testing with UI mode' of the
 // README at /demos/docker/README.md
-const pollOption = playwrightEnv.FILE_CHANGES_DETECTION_SUPPORTED ? "" : "--poll 1500";
+const pollOption = playwrightEnv.FILE_CHANGES_DETECTION_SUPPORTED
+  ? ""
+  : "--poll 1500";
 const _webServerCommand = playwrightCliOptions.UIMode
   ? `npx ng serve --host ${_webServerHost} --port ${_webServerPort} ${pollOption}`
   : `npx ng serve --host ${_webServerHost} --port ${_webServerPort} --watch false`;
@@ -27,9 +29,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/docker/playwright.config.ts
+++ b/demos/docker/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -22,6 +22,28 @@ const _testsDir = path.resolve("./tests");
 const _testResultsDir = path.resolve("./test-results");
 const _htmlReportDir = path.resolve("playwright-html-report");
 
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    [
+      /* See https://playwright.dev/docs/test-reporters#html-reporter */
+      "html",
+      {
+        open: "never",
+        outputFolder: _htmlReportDir,
+      },
+    ],
+  ];
+}
+
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
   testDir: _testsDir,
@@ -35,17 +57,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/ci#workers */
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    [
-      /* See https://playwright.dev/docs/test-reporters#html-reporter */
-      "html",
-      {
-        open: "never",
-        outputFolder: _htmlReportDir,
-      },
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/fixtures/playwright.config.ts
+++ b/demos/fixtures/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -17,6 +17,28 @@ const _webServerCommand = playwrightCliOptions.UIMode
   ? `npx ng serve --host ${_webServerHost} --port ${_webServerPort}`
   : `npx ng serve --host ${_webServerHost} --port ${_webServerPort} --watch false`;
 
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    /* See https://playwright.dev/docs/test-reporters#html-reporter */
+    [
+      "html",
+      {
+        open: "never",
+        outputFolder: path.resolve("playwright-html-report"),
+      },
+    ],
+  ];
+}
+
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
   testDir: path.resolve("./tests"),
@@ -30,17 +52,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/ci#workers */
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    /* See https://playwright.dev/docs/test-reporters#html-reporter */
-    [
-      "html",
-      {
-        open: "never",
-        outputFolder: path.resolve("playwright-html-report"),
-      },
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/fixtures/playwright.config.ts
+++ b/demos/fixtures/playwright.config.ts
@@ -22,9 +22,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/monocart-reporter-advanced-config/playwright.config.ts
+++ b/demos/monocart-reporter-advanced-config/playwright.config.ts
@@ -20,9 +20,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/demos/monocart-reporter-advanced-config/playwright.config.ts
+++ b/demos/monocart-reporter-advanced-config/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -15,6 +15,25 @@ const _webServerCommand = playwrightCliOptions.UIMode
 const _testsDir = path.resolve("./tests");
 const _testResultsDir = path.resolve("./test-results");
 
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    [
+      // See https://github.com/cenfun/monocart-reporter
+      "monocart-reporter",
+      getMonocartReporterOptions(_testResultsDir),
+    ],
+  ];
+}
+
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
   testDir: _testsDir,
@@ -30,14 +49,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/test-global-setup-teardown#option-2-configure-globalsetup-and-globalteardown */
   globalSetup: require.resolve("./playwright.global-setup.ts"),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    [
-      // See https://github.com/cenfun/monocart-reporter
-      "monocart-reporter",
-      getMonocartReporterOptions(_testResultsDir),
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/stale-screenshots-cleanup/playwright.config.ts
+++ b/demos/stale-screenshots-cleanup/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { ReporterDescription, defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { playwrightCliOptions } from "playwright.cli-options";
 import { playwrightEnv } from "playwright.env-vars";
@@ -11,6 +11,28 @@ const _webServerUrl = `http://${_webServerHost}:${_webServerPort}`;
 const _webServerCommand = playwrightCliOptions.UIMode
   ? `npx ng serve --host ${_webServerHost} --port ${_webServerPort}`
   : `npx ng serve --host ${_webServerHost} --port ${_webServerPort} --watch false`;
+
+let _reporters: ReporterDescription[];
+if (playwrightCliOptions.UIMode) {
+  // Limit the reporters when running in UI mode.
+  // This speeds up UI mode since each reporter takes time creating their report after a test run.
+  // For maximum efficiency you could leave the reporters empty when running in UI mode.
+  _reporters = [
+    ["list"],
+  ];
+} else {
+  _reporters = [
+    ["list"],
+    /* See https://playwright.dev/docs/test-reporters#html-reporter */
+    [
+      "html",
+      {
+        open: "never",
+        outputFolder: path.resolve("playwright-html-report"),
+      },
+    ],
+  ];
+}
 
 // See https://playwright.dev/docs/test-configuration.
 export default defineConfig({
@@ -25,17 +47,7 @@ export default defineConfig({
   /* See https://playwright.dev/docs/ci#workers */
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["list"],
-    /* See https://playwright.dev/docs/test-reporters#html-reporter */
-    [
-      "html",
-      {
-        open: "never",
-        outputFolder: path.resolve("playwright-html-report"),
-      },
-    ],
-  ],
+  reporter: _reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/demos/stale-screenshots-cleanup/playwright.config.ts
+++ b/demos/stale-screenshots-cleanup/playwright.config.ts
@@ -17,9 +17,7 @@ if (playwrightCliOptions.UIMode) {
   // Limit the reporters when running in UI mode.
   // This speeds up UI mode since each reporter takes time creating their report after a test run.
   // For maximum efficiency you could leave the reporters empty when running in UI mode.
-  _reporters = [
-    ["list"],
-  ];
+  _reporters = [["list"]];
 } else {
   _reporters = [
     ["list"],

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -5,6 +5,7 @@
 - [Should you use Git LFS when you use screenshots?](#should-you-use-git-lfs-when-you-use-screenshots)
 - [The `webServer.reuseExistingServer` configuration option](#the-webserverreuseexistingserver-configuration-option)
 - [Which reporters should I use?](#which-reporters-should-i-use)
+- [Limit reporters when running in UI mode](#limit-reporters-when-running-in-ui-mode)
 - [You might not need to run all your tests against all your projects](#you-might-not-need-to-run-all-your-tests-against-all-your-projects)
 - [Avoid using watch mode on the target test apps](#avoid-using-watch-mode-on-the-target-test-apps)
 - [What are the available devices for test projects configuration?](#what-are-the-available-devices-for-test-projects-configuration)
@@ -111,6 +112,28 @@ For some usage examples see the following demos:
 - [accessibility-lighthouse](/demos/accessibility-lighthouse/)
 
 **Also, take a look at the [table of contents for the monocart-reporter's documentation](https://github.com/cenfun/monocart-reporter?tab=readme-ov-file#monocart-reporter) to understand the breadth of options this HTML reporter gives you.**
+
+## Limit reporters when running in UI mode
+
+After you execute a test in [Playwright's UI mode](https://playwright.dev/docs/test-ui-mode) the configured reporters in your [playwright.config.ts](https://playwright.dev/docs/test-reporters) are still executed and depending on the size of your app and which reporters you are using this might mean that there's a noticeable delay between a test completes, meaning it shows as passed/failed, and the UI mode being available to execute another test run.
+
+The delay comes from the time it takes for all the reporters generate their reports. When a test finishes the UI mode updates its status to pass/fail immediately, then runs all the reporters and the UI mode won't complete the test execution until the reporters complete.
+
+The video below demonstrates the issue. Notice how the test run finishes, the test is marked as a pass but the `stop` test run button is still available for as long as it takes for the test reporters to complete.
+
+> [!NOTE]
+>
+> This video is taken on an application running the [UI mode via Docker](/demos//docker/README.md), which is also configured to [generate code coverage](/demos/code-coverage-with-monocart-reporter/README.md) and uses the `list` and [monocart-reporter](/demos/monocart-reporter-advanced-config/README.md) reporters.
+>
+> All this adds up and makes it easier to demonstrate the delay issue.
+>
+
+The `playwright.config.ts` in any of the [demos](/demos/) shows how you can limit the `reporters` that run in UI mode.
+
+> [!NOTE]
+>
+> Of course, if you don't notice any delay or you need the information from the reporters even in UI mode then you don't have to limit the reporters in UI mode.
+>
 
 ## You might not need to run all your tests against all your projects
 


### PR DESCRIPTION
Reporters add time to the UI mode execution of a test run. Executing a test in UI mode is still going to execute the reporters at the end and if the longer the reporters take to complete, the longer the UI mode will take to let you execute another test run.

This PR makes limits the reporters that run when executing tests with UI mode and updates the Playwright tips accordingly.