### PR TITLE
Add `test:clean-screenshots` npm command to Docker demo

### DIFF
--- a/demos/docker/.gitignore
+++ b/demos/docker/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 /blob-report/
 /playwright/.cache/
 /tests/__screenshots__/win32
+/tests/__temp-screenshots__/

--- a/demos/docker/docker-compose.yml
+++ b/demos/docker/docker-compose.yml
@@ -25,3 +25,4 @@ services:
     environment:
       CI: ${CI:-false}
       USE_DOCKER_HOST_WEBSERVER: ${USE_DOCKER_HOST_WEBSERVER:-false}
+      SNAPSHOT_DIR: ${SNAPSHOT_DIR}

--- a/demos/docker/npm-pwsh-scripts/clean-stale-screenshots.ps1
+++ b/demos/docker/npm-pwsh-scripts/clean-stale-screenshots.ps1
@@ -1,0 +1,144 @@
+# This script detects stale Playwright screenshots and removes them.
+# This script will be required for as long as Playwright doesn't provide a built-in alternative.
+# See: https://github.com/microsoft/playwright/issues/16582
+#
+
+param(
+  [string] $snapshotDir,
+  [string] $tempSnapshotDir,
+  [int] $maxAttempts = 5,
+  [switch]$dryRun = $false
+)
+
+function CreateTempScreenshots(
+  [int] $maxAttempts,
+  [string] $tempSnapshotDir
+) {
+  # Run Playwright to generate the expected snapshots
+  $attemptsCount = 0;
+  do {
+    $attemptsCount++;
+    Write-Host "📄 Generating expected snapshots (attempt ${attemptsCount} / $maxAttempts)`n" -ForegroundColor Cyan;
+    npm run test '--' -testOptions --update-snapshots -snapshotDir $tempSnapshotDir;
+  } until ($LASTEXITCODE -eq 0 -or $attemptsCount -ge $maxAttempts);
+
+  # Check if all attempts have failed
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host "❌ Failed to generate the expected snapshots after $attemptsCount attempts." -ForegroundColor Red;
+    exit 1;
+  }
+}
+
+function GetStaleScreenshots(
+  [string] $snapshotDir,
+  [string] $tempSnapshotDir
+) {
+  # Determine which files are unused
+  Write-Host "🔍 Searching for stale snapshots..." -ForegroundColor Cyan;
+
+  $currentSnapshotFiles = Get-ChildItem -Recurse -File -Path $snapshotDir;
+  $currentSnapshotRelativeFilePaths = @();
+  $snapshotDirAsAbsolutePath = Resolve-Path -Path $snapshotDir
+  foreach ($currentSnapshotFile in $currentSnapshotFiles) {
+    $currentSnapshotRelativeFilePaths += [System.IO.Path]::GetRelativePath($snapshotDirAsAbsolutePath, $currentSnapshotFile.FullName);
+  }
+
+  $tempSnapshotFiles = Get-ChildItem -Recurse -File -Path $tempSnapshotDir;
+  $tempSnapshotRelativeFilePaths = @();
+  $tempSnapshotDirAsAbsolutePath = Resolve-Path -Path $tempSnapshotDir
+  foreach ($tempSnapshotFile in $tempSnapshotFiles) {
+    $tempSnapshotRelativeFilePaths += [System.IO.Path]::GetRelativePath($tempSnapshotDirAsAbsolutePath, $tempSnapshotFile.FullName);
+  }
+
+  $diffResults = @(Compare-Object -ReferenceObject $tempSnapshotRelativeFilePaths -DifferenceObject $currentSnapshotRelativeFilePaths);
+
+  $staleScreenshots = @();
+  foreach ($diffItem in $diffResults) {
+    # See https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/compare-object#description
+    # Entries that exist on the ReferenceObject only have a SideIndicator of <=
+    # Entrie that exist on the DifferenceObject only have a SideIndicator of =>
+    if ($diffItem.SideIndicator -eq "=>") {
+      # These entries only exist on the DifferenceObject, which is the current
+      # snapshots dir. Since they don't exist on the temp snapshot dir it means these
+      # are the stale entries.
+      $staleScreenshotFullPath = Join-Path $snapshotDir $diffItem.InputObject;
+      $staleScreenshots += $staleScreenshotFullPath;
+    }
+  }
+
+  $staleScreenshotsData = [PSCustomObject]@{
+    TotalScreenshotsCount = $currentSnapshotFiles.Count
+    StaleScreenshotsCount = $staleScreenshots.Count
+    StaleScreenshots      = $staleScreenshots
+  }
+  return $staleScreenshotsData;
+}
+
+function WriteStaleScreenshots(
+  [string[]] $staleScreenshots
+) {
+  foreach ($staleScreenshotFilePath in $staleScreenshots) {
+    $fileRelativePath = $staleScreenshotFilePath | Resolve-Path -Relative;
+    Write-Host "* $fileRelativePath" -ForegroundColor Cyan;
+  }
+
+  Write-Host "`n😶 Stale screenshots weren't deleted because this was a dry run." -ForegroundColor DarkYellow;
+}
+
+function RemoveStaleScreenshots(
+  [string[]] $staleScreenshots
+) {
+  foreach ($staleScreenshotFilePath in $staleScreenshots) {
+    $fileRelativePath = $staleScreenshotFilePath | Resolve-Path -Relative;
+    Write-Host "* Deleting stale screenshot: $fileRelativePath" -ForegroundColor Cyan;
+    Remove-Item -Path $staleScreenshotFilePath;
+  }
+
+  Write-Host ""; # just for the new line after the delete screenshot messages
+
+  # Check if there are any empty folders left after deleting the screenhots and remove them
+  Get-ChildItem $snapshotDir -Recurse -Force -Directory
+  | Sort-Object -Property FullName -Descending
+  | Where-Object { $($_ | Get-ChildItem -Force | Select-Object -First 1).Count -eq 0 }
+  | Remove-Item;
+}
+
+function Remove-TempSnapshotsDirectory(
+  [string] $tempSnapshotDir
+) {
+  Remove-Item -Recurse -Path $tempSnapshotDir -ErrorAction SilentlyContinue;
+}
+
+function StartStaleScreenshotsCleanup {
+  $ErrorActionPreference = 'Stop';
+  $env:SNAPSHOT_DIR = $tempSnapshotDir; # This environment variable is picked up by the playwright.config.ts so that the screenshots are generated on a temp dir.
+
+  Remove-TempSnapshotsDirectory -tempSnapshotDir $tempSnapshotDir;
+  CreateTempScreenshots -maxAttempts $maxAttempts -tempSnapshotDir $tempSnapshotDir;
+  $staleScreenshots = GetStaleScreenshots -snapshotDir $snapshotDir -tempSnapshotDir $tempSnapshotDir;
+  $hasStaleScreenshots = $staleScreenshots.StaleScreenshotsCount -ne 0;
+  if (!$hasStaleScreenshots) {
+    Write-Host "✅ Didn't find any stale screenshot in a total of $($staleScreenshots.TotalScreenshotsCount) screenshots." -ForegroundColor Green;
+  }
+  else {
+    Write-Host "👀 Found $($staleScreenshots.StaleScreenshotsCount) stale screenshots in a total of $($staleScreenshots.TotalScreenshotsCount) screenshots.`n" -ForegroundColor DarkYellow;
+
+    if ($dryRun) {
+      WriteStaleScreenshots -staleScreenshots $staleScreenshots.StaleScreenshots;
+    }
+    else {
+      RemoveStaleScreenshots -staleScreenshots $staleScreenshots.StaleScreenshots;
+    }
+  }
+
+  Remove-TempSnapshotsDirectory -tempSnapshotDir $tempSnapshotDir;
+  Write-Host "✅ Finished cleaning Playwright stale screenshots." -ForegroundColor Green;
+
+  if($hasStaleScreenshots) {
+    Exit 2;
+  }
+
+  Exit 0;
+}
+
+StartStaleScreenshotsCleanup;

--- a/demos/docker/npm-pwsh-scripts/playwright.ps1
+++ b/demos/docker/npm-pwsh-scripts/playwright.ps1
@@ -10,7 +10,8 @@ param (
   [string] $webServerHost = "127.0.0.1",
   [string] $webServerPort = "4200",
   [ValidateSet("auto", "supported", "unsupported")]
-  [string] $fileChangesDetectionSupportMode = "auto"
+  [string] $fileChangesDetectionSupportMode = "auto",
+  [string] $snapshotDir = ""
 )
 
 function GetPlaywrightVersion() {
@@ -90,6 +91,7 @@ function StartPlaywrightTests {
   Write-Host "-webServerMode=$webServerMode" -ForegroundColor DarkYellow
   Write-Host "-webServerHost=$webServerHost" -ForegroundColor DarkYellow
   Write-Host "-webServerPort=$webServerPort" -ForegroundColor DarkYellow
+  Write-Host "-snapshotDir=$snapshotDir" -ForegroundColor DarkYellow
   Write-Host "`n" -NoNewline
 
   $playwrightVersion = GetPlaywrightVersion
@@ -109,6 +111,7 @@ function StartPlaywrightTests {
   Write-Host "PLAYWRIGHT_TEST_OPTIONS=$env:PLAYWRIGHT_TEST_OPTIONS" -ForegroundColor DarkYellow
   Write-Host "NPM_INSTALL_COMMAND=$env:NPM_INSTALL_COMMAND" -ForegroundColor DarkYellow
   Write-Host "USE_DOCKER_HOST_WEBSERVER=$env:USE_DOCKER_HOST_WEBSERVER" -ForegroundColor DarkYellow
+  Write-Host "SNAPSHOT_DIR=$env:SNAPSHOT_DIR" -ForegroundColor DarkYellow
   Write-Host "`n" -NoNewline
 
   Write-Host "Starting docker container...`n" -ForegroundColor Cyan

--- a/demos/docker/package.json
+++ b/demos/docker/package.json
@@ -7,6 +7,7 @@
     "test": "pwsh -NoProfile -File ./npm-pwsh-scripts/playwright.ps1 -webServerHost 127.0.0.1 -webServerPort 4200",
     "test:ui": "pwsh -NoProfile -File ./npm-pwsh-scripts/playwright.ps1 -ui -webServerHost 127.0.0.1 -webServerPort 4200",
     "test:show-report": "npx playwright show-report ./playwright-html-report",
+    "test:clean-screenshots": "pwsh -NoProfile -File ./npm-pwsh-scripts/clean-stale-screenshots.ps1 -snapshotDir ./tests/__screenshots__ -tempSnapshotDir ./tests/__temp-screenshots__",
     "prettier:check": "npx prettier --check .",
     "prettier:write": "npx prettier --write ."
   },

--- a/demos/docker/playwright.config.ts
+++ b/demos/docker/playwright.config.ts
@@ -71,7 +71,9 @@ export default defineConfig({
    * The default snapshotPathTemplate is defined at https://github.com/microsoft/playwright/blob/7bffff5790e28243a815c985135e908247b563db/packages/playwright/src/common/config.ts#L167C5-L167C138
    */
   // prettier-ignore
-  snapshotPathTemplate: "{snapshotDir}/__screenshots__/{platform}/{projectName}/{testFilePath}/{arg}{ext}",
+  snapshotPathTemplate: "{snapshotDir}/{platform}/{projectName}/{testFilePath}/{arg}{ext}",
+  /* the path.resolve with "." below is to avoid any issues when passing relative paths for the SNAPSHOT_DIR into the Docker container */
+  snapshotDir: path.resolve(".", playwrightEnv.SNAPSHOT_DIR),
   /* Configure projects for major browsers */
   projects: [
     {

--- a/demos/docker/playwright.env-vars.ts
+++ b/demos/docker/playwright.env-vars.ts
@@ -1,7 +1,14 @@
+import path from "path";
 import z from "zod";
 
 // Validating environment variables with zod
 // - https://jfranciscosousa.com/blog/validating-environment-variables-with-zod/
+
+// For normal test runs screenshots are added in this directory.
+// When running the npm command 'test:clean-screenshots' the screenshots are created in a temp
+// directory by providing a value to the environment variable SNAPSHOT_DIR.
+const _defaultSnapshotDir = path.resolve("./tests/__screenshots__");
+
 const _envSchema = z.object({
   CI: z
     .enum(["0", "1", "true", "false", "True", "False"])
@@ -15,5 +22,17 @@ const _envSchema = z.object({
     .enum(["0", "1", "true", "false", "True", "False"])
     .catch("false")
     .transform(value => value === "true" || value === "1" || value === "True"),
+  // The transform below makes it so that we can set to use the default snapshot dir if
+  // the SNAPSHOT_DIR environment variable is set to a blank string, not just when it's undefined.
+  //
+  // - SNAPSHOT_DIR will be undefined when running tests in UI mode or if the Playwright tests are executed outside of the current Docker setup.
+  // - SNAPSHOT_DIR will be a blank string when executing tests normally. Meaning when doing 'npm test'.
+  // - SNAPSHOT_DIR will have a value for a temp directory when running the 'test:clean-screenshots' NPM command. This command
+  // needs to recreate all the screenshots in a different directory from the default to them do a diff with the default dir and find
+  // stale screenshots that should be deleted.
+  SNAPSHOT_DIR: z
+    .string()
+    .default(_defaultSnapshotDir)
+    .transform(x => (x === "" ? _defaultSnapshotDir : x)),
 });
 export const playwrightEnv = _envSchema.parse(process.env);


### PR DESCRIPTION
This PR shows how we can integrate the [Cleanup Playwright stale screenshots](https://github.com/edumserrano/playwright-adventures/blob/main/demos/stale-screenshots-cleanup/README.md) demo with Docker.